### PR TITLE
Add project_id to opts

### DIFF
--- a/dradis-projects.gemspec
+++ b/dradis-projects.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
 
-  spec.add_dependency 'dradis-plugins', '~> 3.6'
+  spec.add_dependency 'dradis-plugins', '~> 3.6.2'
   spec.add_dependency 'rubyzip', '~> 1.2.1'
 end

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -17,6 +17,7 @@ class ExportTasks < Thor
     logger        = Logger.new(STDOUT)
     logger.level  = Logger::DEBUG
     opts[:logger] = logger
+    opts[:project_id] = ENV['PROJECT_ID'].to_i if ENV.key?('PROJECT_ID')
 
     template_path = options.file || Rails.root.join('backup').to_s
     FileUtils.mkdir_p(template_path) unless File.exist?(template_path)
@@ -58,6 +59,7 @@ class ExportTasks < Thor
     logger        = Logger.new(STDOUT)
     logger.level  = Logger::DEBUG
     opts[:logger] = logger
+    opts[:project_id] = ENV['PROJECT_ID'].to_i if ENV.key?('PROJECT_ID')
 
     package_path  = options.file || Rails.root.join('backup')
     FileUtils.mkdir_p(package_path) unless File.exist?(package_path)

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -10,9 +10,7 @@ class ExportTasks < Thor
   def template
     require 'config/environment'
 
-    STDOUT.sync   = true
-    logger        = Logger.new(STDOUT)
-    logger.level  = Logger::DEBUG
+    logger = default_logger
     task_options[:logger] = logger
 
     template_path = options.file || Rails.root.join('backup').to_s
@@ -48,9 +46,7 @@ class ExportTasks < Thor
   def package
     require 'config/environment'
 
-    STDOUT.sync   = true
-    logger        = Logger.new(STDOUT)
-    logger.level  = Logger::DEBUG
+    logger = default_logger
     task_options[:logger] = logger
 
     package_path  = options.file || Rails.root.join('backup')
@@ -72,6 +68,13 @@ class ExportTasks < Thor
     logger.close
   end
 
+  private
+  def default_logger
+    STDOUT.sync   = true
+    logger        = Logger.new(STDOUT)
+    logger.level  = Logger::DEBUG
+    logger
+  end
 end
 
 class UploadTasks < Thor

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -10,14 +10,10 @@ class ExportTasks < Thor
   def template
     require 'config/environment'
 
-    # The options we'll end up passing to the Processor class
-    opts = {}
-
     STDOUT.sync   = true
     logger        = Logger.new(STDOUT)
     logger.level  = Logger::DEBUG
-    opts[:logger] = logger
-    opts[:project_id] = ENV['PROJECT_ID'].to_i if ENV.key?('PROJECT_ID')
+    task_options[:logger] = logger
 
     template_path = options.file || Rails.root.join('backup').to_s
     FileUtils.mkdir_p(template_path) unless File.exist?(template_path)
@@ -34,7 +30,7 @@ class ExportTasks < Thor
     detect_and_set_project_scope
 
     exporter_class = Rails.application.config.dradis.projects.template_exporter
-    export_options = opts.merge(plugin: Dradis::Plugins::Projects)
+    export_options = task_options.merge(plugin: Dradis::Plugins::Projects)
     exporter       = exporter_class.new(export_options)
 
     File.open(template_path, 'w') { |f| f.write exporter.export() }
@@ -52,14 +48,10 @@ class ExportTasks < Thor
   def package
     require 'config/environment'
 
-    # The options we'll end up passing to the Processor class
-    opts = {}
-
     STDOUT.sync   = true
     logger        = Logger.new(STDOUT)
     logger.level  = Logger::DEBUG
-    opts[:logger] = logger
-    opts[:project_id] = ENV['PROJECT_ID'].to_i if ENV.key?('PROJECT_ID')
+    task_options[:logger] = logger
 
     package_path  = options.file || Rails.root.join('backup')
     FileUtils.mkdir_p(package_path) unless File.exist?(package_path)
@@ -72,7 +64,7 @@ class ExportTasks < Thor
 
     detect_and_set_project_scope
 
-    export_options = opts.merge(plugin: Dradis::Plugins::Projects)
+    export_options = task_options.merge(plugin: Dradis::Plugins::Projects)
     Dradis::Plugins::Projects::Export::Package.new(export_options).
       export(filename: package_path)
 

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -10,9 +10,6 @@ class ExportTasks < Thor
   def template
     require 'config/environment'
 
-    logger = default_logger
-    task_options[:logger] = logger
-
     template_path = options.file || Rails.root.join('backup').to_s
     FileUtils.mkdir_p(template_path) unless File.exist?(template_path)
 
@@ -46,9 +43,6 @@ class ExportTasks < Thor
   def package
     require 'config/environment'
 
-    logger = default_logger
-    task_options[:logger] = logger
-
     package_path  = options.file || Rails.root.join('backup')
     FileUtils.mkdir_p(package_path) unless File.exist?(package_path)
 
@@ -66,14 +60,6 @@ class ExportTasks < Thor
 
     logger.info{ "Project package created at:\n\t#{ File.expand_path( package_path ) }" }
     logger.close
-  end
-
-  private
-  def default_logger
-    STDOUT.sync   = true
-    logger        = Logger.new(STDOUT)
-    logger.level  = Logger::DEBUG
-    logger
   end
 end
 


### PR DESCRIPTION


### Spec
Currently, the `dradis:plugins:projects:export:package` thor command fails with a stack trace. 

This example command:

`$ PROJECT_ID=96 RAILS_ENV=production bundle exec thor dradis:plugins:projects:export:package`

Fails with the following stack trace: 

```
D, [2017-04-05T21:12:03.883127 #4689] DEBUG -- : Creating a new Zip file in /opt/dradispro/dradispro/releases/20160721072805/backup/dradis-export_2017-04-05_2.zip...
D, [2017-04-05T21:12:03.891617 #4689] DEBUG -- : 	Adding XML repository dump
/opt/dradispro/dradispro/releases/20160721072805/vendor/cache/dradis-plugins-3a24c50550ac/lib/dradis/plugins/content_service/boards.rb:6:in `all_boards': undefined method `id' for nil:NilClass (NoMethodError)
	from /opt/dradispro/dradispro/releases/20160721072805/lib/dradis/pro/plugins/projects/export/v2/template.rb:6:in `build_methodologies'
	from /opt/dradispro/dradispro/releases/20160721072805/vendor/cache/dradis-projects-1c29dd12967d/lib/dradis/plugins/projects/export/template.rb:11:in `block in export'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/builder-3.2.3/lib/builder/xmlbase.rb:175:in `call'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/builder-3.2.3/lib/builder/xmlbase.rb:175:in `_nested_structures'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/builder-3.2.3/lib/builder/xmlbase.rb:68:in `tag!'
	from /opt/dradispro/dradispro/releases/20160721072805/vendor/cache/dradis-projects-1c29dd12967d/lib/dradis/plugins/projects/export/template.rb:8:in `export'
	from /opt/dradispro/dradispro/releases/20160721072805/vendor/cache/dradis-projects-1c29dd12967d/lib/dradis/plugins/projects/export/package.rb:31:in `block in export'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/rubyzip-1.2.1/lib/zip/file.rb:101:in `open'
	from /opt/dradispro/dradispro/releases/20160721072805/vendor/cache/dradis-projects-1c29dd12967d/lib/dradis/plugins/projects/export/package.rb:17:in `export'
	from /opt/dradispro/dradispro/releases/20160721072805/vendor/cache/dradis-projects-1c29dd12967d/lib/tasks/thorfile.rb:75:in `package'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/runner.rb:44:in `method_missing'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/command.rb:29:in `run'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/command.rb:126:in `run'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/bin/thor:6:in `<top (required)>'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/bin/thor:23:in `load'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/bin/thor:23:in `<main>'
```

**Proposed solution**
Another case of the missing `@project.id`?

### How to test
Make sure that a command like: 

`$ PROJECT_ID=96 RAILS_ENV=production bundle exec thor dradis:plugins:projects:export:package`

completes without an error and that the `.zip` file exported to the correct location. 

Upload the exported `.zip` file to a new/blank project to make sure it's properly formed. 