### PR TITLE
Fix upload task

### DIFF
--- a/dradis-projects.gemspec
+++ b/dradis-projects.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
 
-  spec.add_dependency 'dradis-plugins', '~> 3.6'
+  spec.add_dependency 'dradis-plugins', '~> 3.6.2'
   spec.add_dependency 'rubyzip', '~> 1.2.1'
 end

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -91,10 +91,6 @@ class UploadTasks < Thor
   def template(file_path)
     require 'config/environment'
 
-    logger = Logger.new(STDOUT)
-    logger.level = Logger::DEBUG
-    task_options[:logger] = logger
-
     unless File.exists?(file_path)
       $stderr.puts "** the file [#{file_path}] does not exist"
       exit -1
@@ -117,10 +113,6 @@ class UploadTasks < Thor
   desc "package FILE", "import an entire repository package"
   def package(file_path)
     require 'config/environment'
-
-    logger = Logger.new(STDOUT)
-    logger.level = Logger::DEBUG
-    task_options[:logger] = logger
 
     unless File.exists?(file_path)
       $stderr.puts "** the file [#{file_path}] does not exist"

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -93,6 +93,7 @@ class UploadTasks < Thor
 
     logger = Logger.new(STDOUT)
     logger.level = Logger::DEBUG
+    task_options[:logger] = logger
 
     unless File.exists?(file_path)
       $stderr.puts "** the file [#{file_path}] does not exist"
@@ -101,10 +102,9 @@ class UploadTasks < Thor
 
     detect_and_set_project_scope
 
-    opts = {logger: logger, plugin: Dradis::Plugins::Projects::Upload::Template}
-    opts.merge!(project_id: ENV['PROJECT_ID'].to_i) if ENV.key?('PROJECT_ID')
+    task_options.merge!(plugin: Dradis::Plugins::Projects::Upload::Template)
 
-    importer = Dradis::Plugins::Projects::Upload::Template::Importer.new(opts)
+    importer = Dradis::Plugins::Projects::Upload::Template::Importer.new(task_options)
     importer.import(file: file_path)
 
     logger.close
@@ -120,6 +120,7 @@ class UploadTasks < Thor
 
     logger = Logger.new(STDOUT)
     logger.level = Logger::DEBUG
+    task_options[:logger] = logger
 
     unless File.exists?(file_path)
       $stderr.puts "** the file [#{file_path}] does not exist"
@@ -128,10 +129,9 @@ class UploadTasks < Thor
 
     detect_and_set_project_scope
 
-    opts = {logger: logger, plugin: Dradis::Plugins::Projects::Upload::Package}
-    opts.merge!(project_id: ENV['PROJECT_ID'].to_i) if ENV.key?('PROJECT_ID')
+    task_options.merge!(plugin: Dradis::Plugins::Projects::Upload::Package)
 
-    importer = Dradis::Plugins::Projects::Upload::Package::Importer.new(opts)
+    importer = Dradis::Plugins::Projects::Upload::Package::Importer.new(task_options)
     importer.import(file: file_path)
 
     logger.close

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -101,15 +101,10 @@ class UploadTasks < Thor
 
     detect_and_set_project_scope
 
-    content_service  = Dradis::Plugins::ContentService.new(plugin: Dradis::Plugins::Projects::Upload::Template)
-    template_service = Dradis::Plugins::TemplateService.new(plugin: Dradis::Plugins::Projects::Upload::Template)
+    opts = {logger: logger, plugin: Dradis::Plugins::Projects::Upload::Template}
+    opts.merge!(project_id: ENV['PROJECT_ID'].to_i) if ENV.key?('PROJECT_ID')
 
-    importer = Dradis::Plugins::Projects::Upload::Template::Importer.new(
-      logger:           logger,
-      content_service:  content_service,
-      template_service: template_service
-    )
-
+    importer = Dradis::Plugins::Projects::Upload::Template::Importer.new(opts)
     importer.import(file: file_path)
 
     logger.close
@@ -134,11 +129,9 @@ class UploadTasks < Thor
     detect_and_set_project_scope
 
     opts = {logger: logger, plugin: Dradis::Plugins::Projects::Upload::Package}
-
     opts.merge!(project_id: ENV['PROJECT_ID'].to_i) if ENV.key?('PROJECT_ID')
 
     importer = Dradis::Plugins::Projects::Upload::Package::Importer.new(opts)
-
     importer.import(file: file_path)
 
     logger.close

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -131,17 +131,13 @@ class UploadTasks < Thor
       exit -1
     end
 
-
     detect_and_set_project_scope
 
-    content_service  = Dradis::Plugins::ContentService.new(plugin: Dradis::Plugins::Projects::Upload::Package)
-    template_service = Dradis::Plugins::TemplateService.new(plugin: Dradis::Plugins::Projects::Upload::Package)
+    opts = {logger: logger, plugin: Dradis::Plugins::Projects::Upload::Package}
 
-    importer = Dradis::Plugins::Projects::Upload::Package::Importer.new(
-                logger: logger,
-       content_service: content_service,
-      template_service: template_service
-    )
+    opts.merge!(project_id: ENV['PROJECT_ID'].to_i) if ENV.key?('PROJECT_ID')
+
+    importer = Dradis::Plugins::Projects::Upload::Package::Importer.new(opts)
 
     importer.import(file: file_path)
 


### PR DESCRIPTION
### Spec
The `dradis:plugins:projects:upload:package` command currently fails with a stack trace. 

The following sample command: 
`$ PROJECT_ID=96 RAILS_ENV=production bundle exec thor dradis:plugins:projects:upload:package /tmp/dradis-export.zip`

fails with the following stack trace:

```
/opt/dradispro/dradispro/releases/20160721072805/vendor/cache/dradis-projects-1c29dd12967d/lib/tasks/thorfile.rb:137:in `package': undefined method `new' for Dradis::Plugins::ContentService:Module (NoMethodError)
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/runner.rb:44:in `method_missing'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/command.rb:29:in `run'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/command.rb:126:in `run'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/gems/thor-0.19.4/bin/thor:6:in `<top (required)>'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/bin/thor:23:in `load'
	from /opt/dradispro/dradispro/shared/bundle/ruby/2.2.0/bin/thor:23:in `<main>'
```


### How to test
Make sure that a command like: 
`$ PROJECT_ID=96 RAILS_ENV=production bundle exec thor dradis:plugins:projects:upload:package /tmp/dradis-export.zip`
completes without an error. 

Then, open the project and confirm that the project package has been imported correctly. 