### PR TITLE
Fix dradis backup

### DIFF
--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -24,11 +24,12 @@ class ExportTasks < Thor
 
     unless template_path =~ /\.xml\z/
       date          = DateTime.now.strftime("%Y-%m-%d")
-      sequence      = Dir.glob(File.join(template_path, "dradis-template_#{date}_*.xml")).collect do |a|
+      project       = opts[:project_id].nil? ? "" : "_project-#{opts[:project_id]}"
+      sequence      = Dir.glob(File.join(template_path, "dradis-template#{project}_#{date}_*.xml")).collect do |a|
                         a.match(/_([0-9]+)\.xml\z/)[1].to_i
                       end.max || 0
 
-      template_path = File.join(template_path, "dradis-template_#{date}_#{sequence + 1}.xml")
+      template_path = File.join(template_path, "dradis-template#{project}_#{date}_#{sequence + 1}.xml")
     end
 
     detect_and_set_project_scope
@@ -66,8 +67,9 @@ class ExportTasks < Thor
 
     unless package_path.to_s =~ /\.zip\z/
       date      = DateTime.now.strftime("%Y-%m-%d")
-      sequence  = Dir.glob(File.join(package_path, "dradis-export_#{date}_*.zip")).collect { |a| a.match(/_([0-9]+)\.zip\z/)[1].to_i }.max || 0
-      package_path = File.join(package_path, "dradis-export_#{date}_#{sequence + 1}.zip")
+      project   = opts[:project_id].nil? ? "" : "_project-#{opts[:project_id]}"
+      sequence  = Dir.glob(File.join(package_path, "dradis-export#{project}_#{date}_*.zip")).collect { |a| a.match(/_([0-9]+)\.zip\z/)[1].to_i }.max || 0
+      package_path = File.join(package_path, "dradis-export#{project}_#{date}_#{sequence + 1}.zip")
     end
 
     detect_and_set_project_scope
@@ -77,7 +79,7 @@ class ExportTasks < Thor
       export(filename: package_path)
 
     logger.info{ "Project package created at:\n\t#{ File.expand_path( package_path ) }" }
-    logger.close
+    # logger.close # commented, so we do not close STDOUT
   end
 
 end

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -49,7 +49,7 @@ class ExportTasks < Thor
   long_desc "Creates a copy of the current repository, including all nodes, notes and " +
             "attachments as a zipped archive. The backup can be imported into another " +
             "dradis instance using the 'Project Package Upload' option."
-  method_option   :file, type: :string, desc: "the package file to create, or directory to create it in"
+  method_option   :path, type: :string, desc: "the directory to create the package file in"
   def package
     require 'config/environment'
 
@@ -62,15 +62,13 @@ class ExportTasks < Thor
     opts[:logger] = logger
     opts[:project_id] = ENV['PROJECT_ID'].to_i if ENV.key?('PROJECT_ID')
 
-    package_path  = options.file || Rails.root.join('backup')
+    package_path  = options.path || Rails.root.join('backup')
     FileUtils.mkdir_p(package_path) unless File.exist?(package_path)
 
-    unless package_path.to_s =~ /\.zip\z/
-      date      = DateTime.now.strftime("%Y-%m-%d")
-      project   = opts[:project_id].nil? ? "" : "_project-#{opts[:project_id]}"
-      sequence  = Dir.glob(File.join(package_path, "dradis-export#{project}_#{date}_*.zip")).collect { |a| a.match(/_([0-9]+)\.zip\z/)[1].to_i }.max || 0
-      package_path = File.join(package_path, "dradis-export#{project}_#{date}_#{sequence + 1}.zip")
-    end
+    date      = DateTime.now.strftime("%Y-%m-%d")
+    project   = opts[:project_id].nil? ? "" : "_project-#{opts[:project_id]}"
+    sequence  = Dir.glob(File.join(package_path, "dradis-export#{project}_#{date}_*.zip")).collect { |a| a.match(/_([0-9]+)\.zip\z/)[1].to_i }.max || 0
+    package_path = File.join(package_path, "dradis-export#{project}_#{date}_#{sequence + 1}.zip")
 
     detect_and_set_project_scope
 

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -17,6 +17,7 @@ class ExportTasks < Thor
     logger        = Logger.new(STDOUT)
     logger.level  = Logger::DEBUG
     opts[:logger] = logger
+    opts[:project_id] = ENV['PROJECT_ID'].to_i if ENV.key?('PROJECT_ID')
 
     template_path = options.file || Rails.root.join('backup').to_s
     FileUtils.mkdir_p(template_path) unless File.exist?(template_path)
@@ -58,6 +59,7 @@ class ExportTasks < Thor
     logger        = Logger.new(STDOUT)
     logger.level  = Logger::DEBUG
     opts[:logger] = logger
+    opts[:project_id] = ENV['PROJECT_ID'].to_i if ENV.key?('PROJECT_ID')
 
     package_path  = options.file || Rails.root.join('backup')
     FileUtils.mkdir_p(package_path) unless File.exist?(package_path)


### PR DESCRIPTION
Related PR:
https://github.com/dradis/dradis-ce/pull/114

### Spec
The `dradis:backup` command currently fails with a stack trace. 

The following sample command: 
`$ bundle exec thor dradis:backup`

fails with the following stack trace:

```
** Saving backup...                                                   /Users/xavi/.../ce/dradis-ce/lib/tasks/thorfile.rb:26:in `backup': uninitialized constant DradisTasks::ProjectExport (NameError)
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/runner.rb:44:in `method_missing'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/command.rb:29:in `run'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/command.rb:126:in `run'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/gems/thor-0.19.4/bin/thor:6:in `<top (required)>'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/bin/thor:22:in `load'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/bin/thor:22:in `<main>'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `eval'
	from /Users/xavi/.rvm/gems/ruby-2.2.2/bin/ruby_executable_hooks:15:in `<main>'
```


### How to test
Make sure that a command like: 
`$ bundle exec thor dradis:backup`
completes without an error.

Then, check that the backup data can been imported correctly. 

The command should be tested also with the `--path` option, to specify the destination folder:
`$ bundle exec thor dradis:backup --path=/Users/xavi/Desktop/dradis`