### PR TITLE
Catch nil evidence content when exporting

### DIFF
--- a/lib/dradis/plugins/projects/export/v1/template.rb
+++ b/lib/dradis/plugins/projects/export/v1/template.rb
@@ -41,7 +41,7 @@ module Dradis::Plugins::Projects::Export::V1
             evidence_builder.author(evidence.author)
             evidence_builder.tag!('issue-id', evidence.issue_id)
             evidence_builder.content do
-              evidence_builder.cdata!(evidence.content)
+              evidence_builder.cdata!(evidence.content || "")
             end
             build_activities_for(evidence_builder, evidence)
           end


### PR DESCRIPTION
### Spec
Currently, the NeXpose plugin can create Evidences with `nil` content. This can create problems with exporting such as:
```
[NoMethodError] undefined method `gsub' for nil:NilClass
```

#### Proposed Solution:
When exporting , catch the `nil` content for Evidences.

### How to test

1. Create a blank project
1. Go to "Upload output from tool in the app" in Dradis Pro
1. Upload the attached XML using the Nexpose plugin
1. Export the project as a Package or a Template
1. Assert that there were no raised errors when exporting.