### PR TITLE
filter some unicode control characters when exporting xml files

### DIFF
--- a/lib/dradis/plugins/projects/export/template.rb
+++ b/lib/dradis/plugins/projects/export/template.rb
@@ -22,6 +22,9 @@ module Dradis::Plugins::Projects::Export
     def build_nodes(builder);         raise NotImplementedError; end
     def build_tags(builder);          raise NotImplementedError; end
     def version;                      raise NotImplementedError; end
+    def cdata!(builder, text)
+      builder.cdata! text.gsub(/[\u0001-\u0008\u000B\u000C\u000D-\u001F]/ , '')
+    end
   end
 end
 

--- a/lib/dradis/plugins/projects/export/v1/template.rb
+++ b/lib/dradis/plugins/projects/export/v1/template.rb
@@ -41,7 +41,7 @@ module Dradis::Plugins::Projects::Export::V1
             evidence_builder.author(evidence.author)
             evidence_builder.tag!('issue-id', evidence.issue_id)
             evidence_builder.content do
-              evidence_builder.cdata!(evidence.content)
+              cdata!(evidence_builder, evidence.content || "")
             end
             build_activities_for(evidence_builder, evidence)
           end
@@ -58,7 +58,7 @@ module Dradis::Plugins::Projects::Export::V1
             issue_builder.id(issue.id)
             issue_builder.author(issue.author)
             issue_builder.text do
-              issue_builder.cdata!(issue.text)
+              cdata!(issue_builder, issue.text)
             end
             build_activities_for(issue_builder, issue)
           end
@@ -72,7 +72,7 @@ module Dradis::Plugins::Projects::Export::V1
         methodologies.each do |methodology|
           methodologies_builder.methodology do |methodology_builder|
             methodology_builder.text do
-              methodology_builder.cdata!(methodology.text)
+              cdata!(methodology_builder, methodology.text)
             end
           end
         end
@@ -93,7 +93,7 @@ module Dradis::Plugins::Projects::Export::V1
             node_builder.tag!('parent-id', node.parent_id)
             node_builder.position(node.position)
             node_builder.properties do
-              node_builder.cdata!(node.raw_properties)
+              cdata!(node_builder, node.raw_properties)
             end
             node_builder.tag!('type-id', node.type_id)
             # Notes
@@ -114,7 +114,7 @@ module Dradis::Plugins::Projects::Export::V1
             note_builder.author(note.author)
             note_builder.tag!('category-id', note.category_id)
             note_builder.text do
-              note_builder.cdata!(note.text)
+              cdata!(note_builder, note.text)
             end
             build_activities_for(note_builder, note)
           end

--- a/lib/dradis/plugins/projects/export/v1/template.rb
+++ b/lib/dradis/plugins/projects/export/v1/template.rb
@@ -41,7 +41,7 @@ module Dradis::Plugins::Projects::Export::V1
             evidence_builder.author(evidence.author)
             evidence_builder.tag!('issue-id', evidence.issue_id)
             evidence_builder.content do
-              cdata!(evidence_builder, evidence.content || "")
+              cdata!(evidence_builder, evidence.content)
             end
             build_activities_for(evidence_builder, evidence)
           end


### PR DESCRIPTION
In XML spec, not all unicode characters are allowed: https://www.w3.org/TR/2004/REC-xml-20040204/#NT-Char
If we rename this file: [dradis-template.txt](https://github.com/dradis/dradis-projects/files/972857/dradis-template.txt)  as `dradis-template.xml` and try to open it with google chrome, we see an error due to invalid characters being present.

The same happens when parsing that file with nokogiri gem.

As a first approach to this problem, we may filter invalid characters in our `CDATA` sections when generating xml files from dradis.
The idea would be to filter the first 32 unicode characters (control characters), except "tabulation" (`\u0009`), "next line" (`\u000A`) and "carriage return" (`\u000D`) that are allowed.
A list with those characters is available here: https://unicode-table.com/en/#control-character

As a reference, I checked which of these 32 control are accepted by Nokogiri with this script:
```ruby
require 'nokogiri'

control_characters = ("\u0000".."\u001F")

control_characters.each do |c|
  s = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><dradis><![CDATA[#{c}]]></dradis>"
  t = Nokogiri::XML(s)
  if t.errors.empty?
    puts "valid caracter: #{c.unpack("U")}"
  end
end
``` 

---

This PR tries to fix https://github.com/dradis/dradis-ce/issues/116


