### PR TITLE
find a type element inside a node with value 4, then take its parent

### DIFF
--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -335,9 +335,9 @@ module Dradis::Plugins::Projects::Upload::V1
           template.at_xpath(
             "//nodes/node/type-id[text()='#{Node::Types::CONTENTLIB}']"
           )
-        content_library_xml = contentlib_type_id.parent if contentlib_type_id
 
-        if content_library_xml != nil
+        if contentlib_type_id
+          content_library_xml = contentlib_type_id.parent
           document_properties =
             JSON.parse(content_library_xml.at_xpath('properties').text)
 

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -331,10 +331,11 @@ module Dradis::Plugins::Projects::Upload::V1
       def parse_report_content(template)
         logger.info { 'Processing Report Content...' }
 
-        content_library_xml =
-          template.xpath("//nodes/node").first do |xml_nodes|
-            xml_node.at_xpath('type-id').text == Node::Types::CONTENTLIB.to_s
-          end
+        contentlib_type_id =
+          template.at_xpath(
+            "//nodes/node/type-id[text()='#{Node::Types::CONTENTLIB}']"
+          )
+        content_library_xml = contentlib_type_id.parent if contentlib_type_id
 
         if content_library_xml != nil
           document_properties =


### PR DESCRIPTION
While creating a project from an old project template, I found and 'invalid template' error.
Looks like if the project has no report content data (a CONTENTLIB Node), we are not catching it properly.
With this PR, if no info related to the CONTENTLIB Node is found in the xml template, nothing should happen.