### PR TITLE
Export fix: add version attribute to xml exported methodologies  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.8 (XXX, 2017) ##
+
+*   Add version attribute to exported methodologies   
+
 ## Dradis Framework 3.7 (July, 2017) ##
 
 *   Skip closing the logger in thorfile   

--- a/lib/dradis/plugins/projects/export/v1/template.rb
+++ b/lib/dradis/plugins/projects/export/v1/template.rb
@@ -70,7 +70,7 @@ module Dradis::Plugins::Projects::Export::V1
       methodologies = Node.methodology_library.notes
       builder.methodologies do |methodologies_builder|
         methodologies.each do |methodology|
-          methodologies_builder.methodology do |methodology_builder|
+          methodologies_builder.methodology(version: VERSION) do |methodology_builder|
             methodology_builder.text do
               methodology_builder.cdata!(methodology.text)
             end

--- a/lib/dradis/plugins/projects/gem_version.rb
+++ b/lib/dradis/plugins/projects/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 7
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")


### PR DESCRIPTION
## How to test
- Export a CE project that contains methodologies
-  Check the exported xml, assert that `<methodology>` tags have a `version` attribute with value  `1`