### PR TITLE
Fix nodes upload

### DIFF
--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -266,11 +266,6 @@ module Dradis::Plugins::Projects::Upload::V1
 
           # keep track of reassigned ids
           lookup_table[:nodes][xml_node.at_xpath('id').text.strip] = node.id
-
-          if node.parent_id != nil
-            # keep track of orphaned nodes
-            pending_changes[:orphan_nodes] << node
-          end
         end
 
         logger.info { 'Done.' }

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -221,7 +221,7 @@ module Dradis::Plugins::Projects::Upload::V1
         if label == Configuration.plugin_uploads_node
           node = Node.create_with(type_id: type_id, parent_id: parent_id)
               .find_or_create_by!(label: label)
-        elsif [Node::Types::DEFAULT, Node::Types::HOST].exclude?(type_id.to_i)
+        elsif [Node::Types::USER_TYPES].exclude?(type_id.to_i)
           node = Node.create_with(label: label)
               .find_or_create_by!(type_id: type_id)
         else

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -329,6 +329,8 @@ module Dradis::Plugins::Projects::Upload::V1
       end
 
       def parse_report_content(template)
+        return unless defined?(Node::Types::CONTENTLIB)
+
         logger.info { 'Processing Report Content...' }
 
         contentlib_type_id =

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -221,7 +221,7 @@ module Dradis::Plugins::Projects::Upload::V1
         if label == Configuration.plugin_uploads_node
           node = Node.create_with(type_id: type_id, parent_id: parent_id)
               .find_or_create_by!(label: label)
-        elsif [Node::Types::USER_TYPES].exclude?(type_id.to_i)
+        elsif Node::Types::USER_TYPES.exclude?(type_id.to_i)
           node = Node.create_with(label: label)
               .find_or_create_by!(type_id: type_id)
         else


### PR DESCRIPTION
Fixes: http://discuss.dradisframework.org/t/error-while-importing-owasp-project/492

With the new parent validation for nodes, the parsing of nodes in the template upload breaks because it relies on the fact that you can save nodes with invalid parent ID. This solution skips the validation when saving child nodes and only validate them properly when they have the right parent id.

### How to test:
In CE,
1. Download the OWASP package https://dradisframework.com/academy/industry/compliance/owasp/
2. Upload the file .zip file in the package
3. Assert that there were no errors in uploading.
