### PR TITLE
keep system nodes unique

### DIFF
--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -222,7 +222,7 @@ module Dradis::Plugins::Projects::Upload::V1
           if label == Configuration.plugin_uploads_node
             Node.create_with(type_id: type_id, parent_id: parent_id)
                 .find_or_create_by!(label: label)
-          elsif [Node::Types::DEFAULT, Node::Types::HOST].exclude?(type_id.to_i)
+          elsif Node.user_nodes.distinct.pluck(:type_id).exclude?(type_id.to_i)
             Node.create_with(label: label)
                 .find_or_create_by!(type_id: type_id)
           else


### PR DESCRIPTION
I've noticed that we were already keeping some nodes unique on import using their label (the `plugin-output` node).
This PR pretends to keep system nodes unique, detecting them by their type_id
(everything that is not in `Node::Types::DEFAULT` or `Node::Types::HOST` is a system node)