### PR TITLE
Add default user id as fallback for activity user when importing.

### DIFF
--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -374,7 +374,7 @@ module Dradis::Plugins::Projects::Upload::V1
             hash[user.email] = user.id
           end
         end
-        @users[email] || -1
+        @users[email] || @default_user_id
       end
 
       def validate_and_save(instance)

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -368,7 +368,7 @@ module Dradis::Plugins::Projects::Upload::V1
 
       # Cache users to cut down on excess SQL requests
       def user_id_for_email(email)
-        return -1 if email.blank?
+        return @default_user_id if email.blank?
         @users ||= begin
           User.select([:id, :email]).all.each_with_object({}) do |user, hash|
             hash[user.email] = user.id


### PR DESCRIPTION
### Spec

Currently, the importer assigns `-1` as a user id for activities when the user email is missing.

**Proposed solution**

Use the default_user_id instead.


### How to test

1. Create a temporary user.
2. Login to the user and create a project.
3. Perform activities in the project (create/delete/update issues/evidences/nodes)
4. Export the project as a template.
5. Login to a different user (admin).
6. Delete the temporary user.
7. Create a project template using the exported template in #4.
8. Create a project using the project template.
9. Assert that the project was created.