### PR TITLE
Check project existence for default user id

### DIFF
--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -79,7 +79,7 @@ class UploadTasks < Thor
 
     detect_and_set_project_scope
 
-    default_user_id = @project.owners.first.id
+    default_user_id = @project ? @project.owners.first.id : -1
 
     task_options.merge!({
       plugin: Dradis::Plugins::Projects::Upload::Template,
@@ -105,7 +105,7 @@ class UploadTasks < Thor
 
     detect_and_set_project_scope
 
-    default_user_id = @project.owners.first.id
+    default_user_id = @project ? @project.owners.first.id : -1
 
     task_options.merge!({
       plugin: Dradis::Plugins::Projects::Upload::Package,


### PR DESCRIPTION
In CE, when uploading a project through the thor task, an error appears: 
```
NoMethodError: undefined method `owners' for nil:NilClass`.
```

This is because the `@project` variable does not exist in the CE environment. We add a check here to accommodate the missing variable.