### PR TITLE
Comments export import

### DIFF
--- a/lib/dradis/plugins/projects/engine.rb
+++ b/lib/dradis/plugins/projects/engine.rb
@@ -18,8 +18,8 @@ module Dradis
 
         initializer "dradis-projects.set_configs" do |app|
           options = app.config.dradis.projects
-          options.template_exporter ||= Dradis::Plugins::Projects::Export::V1::Template
-          options.template_uploader ||= Dradis::Plugins::Projects::Upload::V1::Template::Importer
+          options.template_exporter ||= Dradis::Plugins::Projects::Export::V2::Template
+          options.template_uploader ||= Dradis::Plugins::Projects::Upload::V2::Template::Importer
         end
 
 

--- a/lib/dradis/plugins/projects/export/template.rb
+++ b/lib/dradis/plugins/projects/export/template.rb
@@ -28,3 +28,4 @@ module Dradis::Plugins::Projects::Export
 end
 
 require_relative 'v1/template'
+require_relative 'v2/template'

--- a/lib/dradis/plugins/projects/export/v1/template.rb
+++ b/lib/dradis/plugins/projects/export/v1/template.rb
@@ -16,6 +16,18 @@ module Dradis::Plugins::Projects::Export::V1
       end
     end
 
+    def build_comments_for(builder, commentable)
+      builder.comments do |comments_builder|
+        commentable.comments.each do |comment|
+          comments_builder.comment do |comment_builder|
+            comment_builder.content(comment.content)
+            comment_builder.author(comment.user.email)
+            comment_builder.created_at(comment.created_at.to_i)
+          end
+        end
+      end
+    end
+
     def build_categories(builder)
       categories = []
       categories << Category.issue if @issues.any?
@@ -44,6 +56,7 @@ module Dradis::Plugins::Projects::Export::V1
               evidence_builder.cdata!(evidence.content)
             end
             build_activities_for(evidence_builder, evidence)
+            build_comments_for(evidence_builder, evidence)
           end
         end
       end
@@ -61,6 +74,7 @@ module Dradis::Plugins::Projects::Export::V1
               issue_builder.cdata!(issue.text)
             end
             build_activities_for(issue_builder, issue)
+            build_comments_for(issue_builder, issue)
           end
         end
       end
@@ -101,6 +115,7 @@ module Dradis::Plugins::Projects::Export::V1
             # Evidence
             build_evidence_for_node(node_builder, node)
             build_activities_for(node_builder, node)
+            build_comments_for(node_builder, node)
           end
         end
       end
@@ -117,6 +132,7 @@ module Dradis::Plugins::Projects::Export::V1
               note_builder.cdata!(note.text)
             end
             build_activities_for(note_builder, note)
+            build_comments_for(note_builder, note)
           end
         end
       end

--- a/lib/dradis/plugins/projects/export/v1/template.rb
+++ b/lib/dradis/plugins/projects/export/v1/template.rb
@@ -56,7 +56,6 @@ module Dradis::Plugins::Projects::Export::V1
               evidence_builder.cdata!(evidence.content)
             end
             build_activities_for(evidence_builder, evidence)
-            build_comments_for(evidence_builder, evidence)
           end
         end
       end
@@ -115,7 +114,6 @@ module Dradis::Plugins::Projects::Export::V1
             # Evidence
             build_evidence_for_node(node_builder, node)
             build_activities_for(node_builder, node)
-            build_comments_for(node_builder, node)
           end
         end
       end
@@ -132,7 +130,6 @@ module Dradis::Plugins::Projects::Export::V1
               note_builder.cdata!(note.text)
             end
             build_activities_for(note_builder, note)
-            build_comments_for(note_builder, note)
           end
         end
       end

--- a/lib/dradis/plugins/projects/export/v1/template.rb
+++ b/lib/dradis/plugins/projects/export/v1/template.rb
@@ -16,18 +16,6 @@ module Dradis::Plugins::Projects::Export::V1
       end
     end
 
-    def build_comments_for(builder, commentable)
-      builder.comments do |comments_builder|
-        commentable.comments.each do |comment|
-          comments_builder.comment do |comment_builder|
-            comment_builder.content(comment.content)
-            comment_builder.author(comment.user.email)
-            comment_builder.created_at(comment.created_at.to_i)
-          end
-        end
-      end
-    end
-
     def build_categories(builder)
       categories = []
       categories << Category.issue if @issues.any?
@@ -73,7 +61,6 @@ module Dradis::Plugins::Projects::Export::V1
               issue_builder.cdata!(issue.text)
             end
             build_activities_for(issue_builder, issue)
-            build_comments_for(issue_builder, issue)
           end
         end
       end

--- a/lib/dradis/plugins/projects/export/v2/template.rb
+++ b/lib/dradis/plugins/projects/export/v2/template.rb
@@ -1,0 +1,40 @@
+module Dradis::Plugins::Projects::Export::V2
+  class Template < Dradis::Plugins::Projects::Export::V1::Template
+    VERSION = 2
+
+    protected
+
+    def build_comments_for(builder, commentable)
+      builder.comments do |comments_builder|
+        commentable.comments.each do |comment|
+          comments_builder.comment do |comment_builder|
+            comment_builder.content do
+              comment_builder.cdata!(comment.content)
+            end
+            comment_builder.author(comment.user.email)
+            comment_builder.created_at(comment.created_at.to_i)
+          end
+        end
+      end
+    end
+
+    def build_issues(builder)
+      @issues = Issue.where(node_id: Node.issue_library).includes(:activities)
+
+      builder.issues do |issues_builder|
+        @issues.each do |issue|
+          issues_builder.issue do |issue_builder|
+            issue_builder.id(issue.id)
+            issue_builder.author(issue.author)
+            issue_builder.text do
+              issue_builder.cdata!(issue.text)
+            end
+            build_activities_for(issue_builder, issue)
+            build_comments_for(issue_builder, issue)
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/lib/dradis/plugins/projects/upload/template.rb
+++ b/lib/dradis/plugins/projects/upload/template.rb
@@ -88,3 +88,4 @@ module Dradis::Plugins::Projects::Upload
 end
 
 require_relative 'v1/template'
+require_relative 'v2/template'

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -26,7 +26,7 @@ module Dradis::Plugins::Projects::Upload::V1
           evidence: [],
 
           # likewise we also need to hold on to the XML about evidence activities
-          # and comments until after the evidence has been saved
+          # until after the evidence has been saved
           evidence_activity: [],
 
           # all children nodes, we will need to find the ID of their new parents.
@@ -240,11 +240,7 @@ module Dradis::Plugins::Projects::Upload::V1
               position:  position
             )
           node.save!(validate: has_nil_parent)
-
-          if parent_id
-            pending_changes[:orphan_nodes]  << node
-          end
-
+          pending_changes[:orphan_nodes]  << node if parent_id
         end
 
         if properties

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -66,6 +66,8 @@ module Dradis::Plugins::Projects::Upload::V1
         return false unless validate_and_save(issue)
 
         return false unless create_activities(issue, xml_issue)
+
+        true
       end
 
       def finalize(template)

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -55,6 +55,19 @@ module Dradis::Plugins::Projects::Upload::V1
         validate_and_save(activity)
       end
 
+      def create_issue(issue, xml_issue)
+        # TODO: Need to find some way of checking for dups
+        # May be combination of text, category_id and created_at
+        issue.author   = xml_issue.at_xpath('author').text.strip
+        issue.text     = xml_issue.at_xpath('text').text
+        issue.node     = Node.issue_library
+        issue.category = Category.issue
+
+        return false unless validate_and_save(issue)
+
+        return false unless create_activities(issue, xml_issue)
+      end
+
       def finalize(template)
         logger.info { 'Wrapping up...' }
 
@@ -137,30 +150,19 @@ module Dradis::Plugins::Projects::Upload::V1
       # Will need to adjust node ID after generating node structure
       def parse_issues(template)
         issue = nil
-        issue_category = Category.issue
-        issue_library  = Node.issue_library
 
         logger.info { 'Processing Issues...' }
 
         template.xpath('dradis-template/issues/issue').each do |xml_issue|
-          old_id = xml_issue.at_xpath('id').text.strip
-
-          # TODO: Need to find some way of checking for dups
-          # May be combination of text, category_id and created_at
           issue = Issue.new
-          issue.author   = xml_issue.at_xpath('author').text.strip
-          issue.text     = xml_issue.at_xpath('text').text
-          issue.node     = issue_library
-          issue.category = issue_category
 
-          return false unless validate_and_save(issue)
-
-          return false unless create_activities(issue, xml_issue)
+          return false unless create_issue(issue, xml_issue)
 
           if issue.text =~ %r{^!(.*)/nodes/(\d+)/attachments/(.+)!$}
             pending_changes[:attachment_notes] << issue
           end
 
+          old_id = xml_issue.at_xpath('id').text.strip
           lookup_table[:issues][old_id] = issue.id
           logger.info{ "New issue detected: #{issue.title}" }
         end

--- a/lib/dradis/plugins/projects/upload/v2/template.rb
+++ b/lib/dradis/plugins/projects/upload/v2/template.rb
@@ -29,6 +29,8 @@ module Dradis::Plugins::Projects::Upload::V2
       def create_issue(issue, xml_issue)
         return false unless super
         return false unless create_comments(issue, xml_issue.xpath('comments/comment'))
+
+        true
       end
     end
   end

--- a/lib/dradis/plugins/projects/upload/v2/template.rb
+++ b/lib/dradis/plugins/projects/upload/v2/template.rb
@@ -13,10 +13,10 @@ module Dradis::Plugins::Projects::Upload::V2
             commentable_type: commentable.class.to_s,
             content: xml_comment.at_xpath('content').text,
             created_at: Time.at(xml_comment.at_xpath('created_at').text.to_i),
-            user_id: find_user_for_comments(author_email)
+            user_id: user_id_for_email(author_email)
           )
 
-          if comment.user_id.nil?
+          if comment.user.email != author_email
             comment.content = comment.content +
               "\n\nThis comment was imported into the project. Original author: "\
               "#{author_email}."
@@ -39,14 +39,6 @@ module Dradis::Plugins::Projects::Upload::V2
         return false unless create_activities(issue, xml_issue)
         return false unless create_comments(issue, xml_issue.xpath('comments/comment'))
       end
-
-      def find_user_for_comments(email)
-        # We call this method to cache the users in @users
-        user_id_for_email(email)
-
-        @users[email] || nil
-      end
-
     end
   end
 end

--- a/lib/dradis/plugins/projects/upload/v2/template.rb
+++ b/lib/dradis/plugins/projects/upload/v2/template.rb
@@ -17,8 +17,17 @@ module Dradis::Plugins::Projects::Upload::V2
         end
       end
 
-      def parse_issues(template)
-        super
+      def create_issue(issue, xml_issue)
+        # TODO: Need to find some way of checking for dups
+        # May be combination of text, category_id and created_at
+        issue.author   = xml_issue.at_xpath('author').text.strip
+        issue.text     = xml_issue.at_xpath('text').text
+        issue.node     = Node.issue_library
+        issue.category = Category.issue
+
+        return false unless validate_and_save(issue)
+
+        return false unless create_activities(issue, xml_issue)
         return false unless create_comments(issue, xml_issue.xpath('comments/comment'))
       end
 

--- a/lib/dradis/plugins/projects/upload/v2/template.rb
+++ b/lib/dradis/plugins/projects/upload/v2/template.rb
@@ -1,0 +1,27 @@
+module Dradis::Plugins::Projects::Upload::V2
+  module Template
+    class Importer < Dradis::Plugins::Projects::Upload::V1::Template::Importer
+      private
+
+      def create_comments(commentable, xml_comments)
+        return true if xml_comments.empty?
+
+        xml_comments.each do |xml_comment|
+          comment = commentable.comments.new(
+            content: xml_comment.at_xpath('content').text,
+            created_at: Time.at(xml_comment.at_xpath('created_at').text.to_i),
+            user_id: user_id_for_email(xml_comment.at_xpath('author').text)
+          )
+
+          return false unless validate_and_save(comment)
+        end
+      end
+
+      def parse_issues(template)
+        super
+        return false unless create_comments(issue, xml_issue.xpath('comments/comment'))
+      end
+
+    end
+  end
+end

--- a/lib/dradis/plugins/projects/upload/v2/template.rb
+++ b/lib/dradis/plugins/projects/upload/v2/template.rb
@@ -18,7 +18,7 @@ module Dradis::Plugins::Projects::Upload::V2
 
           if comment.user.email != author_email
             comment.content = comment.content +
-              "\n\nThis comment was imported into the project. Original author: "\
+              "\n\nOriginal author not available in this Dradis instance: "\
               "#{author_email}."
           end
 
@@ -27,16 +27,7 @@ module Dradis::Plugins::Projects::Upload::V2
       end
 
       def create_issue(issue, xml_issue)
-        # TODO: Need to find some way of checking for dups
-        # May be combination of text, category_id and created_at
-        issue.author   = xml_issue.at_xpath('author').text.strip
-        issue.text     = xml_issue.at_xpath('text').text
-        issue.node     = Node.issue_library
-        issue.category = Category.issue
-
-        return false unless validate_and_save(issue)
-
-        return false unless create_activities(issue, xml_issue)
+        return false unless super
         return false unless create_comments(issue, xml_issue.xpath('comments/comment'))
       end
     end

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -79,7 +79,7 @@ class UploadTasks < Thor
 
     detect_and_set_project_scope
 
-    default_user_id = @project ? @project.owners.first.id : 1
+    default_user_id = @project ? @project.owners.first.id : User.first.id
 
     task_options.merge!({
       plugin: Dradis::Plugins::Projects::Upload::Template,
@@ -105,7 +105,7 @@ class UploadTasks < Thor
 
     detect_and_set_project_scope
 
-    default_user_id = @project ? @project.owners.first.id : 1
+    default_user_id = @project ? @project.owners.first.id : User.first.id
 
     task_options.merge!({
       plugin: Dradis::Plugins::Projects::Upload::Package,


### PR DESCRIPTION
### Spec
We want to have the ability to export/import comments in Projects to be able to migrate the discussion along with the findings.

#### Proposed Solution
Add builders and parsers in dradis-projects for Comments

### How to test
*Note: this PR is more easily tested once there's a way to view comments*
1. Create a project
2. Add an issue
3. Add comments to the issue
4. Export the project
5. Create a new project(2)
6. Upload the export from Step 4 to project(2).
7. Assert that the comments were migrated.
