### PR TITLE
Evidence comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Dradis Framework 3.11 (XXX, 2018) ##
 
-*  Note comments in export/import 
+*  Note and evidence comments in export/import
 
 ## Dradis Framework 3.10 (August, 2018) ##
 

--- a/lib/dradis/plugins/projects/export/v1/template.rb
+++ b/lib/dradis/plugins/projects/export/v1/template.rb
@@ -47,6 +47,7 @@ module Dradis::Plugins::Projects::Export::V1
               evidence_builder.cdata!(evidence.content)
             end
             build_activities_for(evidence_builder, evidence)
+            build_comments_for(evidence_builder, evidence)
           end
         end
       end

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -28,8 +28,9 @@ module Dradis::Plugins::Projects::Upload::V1
           evidence: [],
 
           # likewise we also need to hold on to the XML about evidence activities
-          # until after the evidence has been saved
+          # and comments until after the evidence has been saved
           evidence_activity: [],
+          evidence_comments: [],
 
           # all children nodes, we will need to find the ID of their new parents.
           orphan_nodes: []
@@ -124,6 +125,9 @@ module Dradis::Plugins::Projects::Upload::V1
           pending_changes[:evidence_activity][i].each do |xml_activity|
             raise "Couldn't create activity for Evidence ##{evidence.id}" unless create_activity(evidence, xml_activity)
           end
+
+          xml_comments = pending_changes[:evidence_comments][i]
+          raise "Couldn't create comments for Evidence ##{evidence.id}" unless create_comments(evidence, xml_comments)
         end
       end
 
@@ -306,6 +310,7 @@ module Dradis::Plugins::Projects::Upload::V1
 
             pending_changes[:evidence]          << evidence
             pending_changes[:evidence_activity] << xml_evidence.xpath('activities/activity')
+            pending_changes[:evidence_comments] << xml_evidence.xpath('comments/comment')
 
             logger.info { "\tNew evidence added." }
           end

--- a/spec/fixtures/files/with_comments.xml
+++ b/spec/fixtures/files/with_comments.xml
@@ -1,12 +1,110 @@
-<?xml version="1.0" encoding="UTF-8"?><dradis-template version="2"><nodes><node><id>3</id><label>Node 1</label><parent-id/><position>0</position><properties><![CDATA[{
-}]]></properties><type-id>1</type-id><notes><note><id>2</id><author>xavi</author><category-id>2</category-id><text><![CDATA[#[Title]#
+<?xml version="1.0" encoding="UTF-8"?>
+<dradis-template version="2">
+  <nodes>
+    <node>
+      <id>3</id>
+      <label>Node 1</label>
+      <parent-id/>
+      <position>0</position>
+      <properties><![CDATA[{
+}]]></properties>
+      <type-id>1</type-id>
+      <notes>
+        <note>
+          <id>2</id>
+          <author>xavi</author>
+          <category-id>2</category-id>
+          <text><![CDATA[#[Title]#
 Note 1
 
 #[Description]#
 
-]]></text><activities><activity><action>create</action><user_email>xavi</user_email><created_at>1538467955</created_at></activity></activities><comments><comment><content><![CDATA[A comment on a note]]></content><author>xavi</author><created_at>1538467968</created_at></comment></comments></note></notes><evidence></evidence><activities><activity><action>create</action><user_email>xavi</user_email><created_at>1538467945</created_at></activity></activities></node></nodes><issues><issue><id>1</id><author>xavi</author><text><![CDATA[#[Title]#
+]]></text>
+          <activities>
+            <activity>
+              <action>create</action>
+              <user_email>xavi</user_email>
+              <created_at>1538467955</created_at>
+            </activity>
+          </activities>
+          <comments>
+            <comment>
+              <content><![CDATA[A comment on a note]]></content>
+              <author>xavi</author>
+              <created_at>1538467968</created_at>
+            </comment>
+          </comments>
+        </note>
+      </notes>
+      <evidence>
+        <evidence>
+          <id>386</id>
+          <author>xavi</author>
+          <issue-id>586</issue-id>
+          <content><![CDATA[#[Location]#
+A
+]]></content>
+          <activities>
+            <activity>
+              <action>create</action>
+              <user_email>xavi</user_email>
+              <created_at>1538549260</created_at>
+            </activity>
+          </activities>
+          <comments>
+            <comment>
+              <content><![CDATA[A comment on an evidence]]></content>
+              <author>xavi</author>
+              <created_at>1538549286</created_at>
+            </comment>
+          </comments>
+        </evidence>
+      </evidence>
+      <activities>
+        <activity>
+          <action>create</action>
+          <user_email>xavi</user_email>
+          <created_at>1538467945</created_at>
+        </activity>
+      </activities>
+    </node>
+  </nodes>
+  <issues>
+    <issue>
+      <id>1</id>
+      <author>xavi</author>
+      <text><![CDATA[#[Title]#
 Issue 1
 
 #[Description]#
 
-]]></text><activities><activity><action>create</action><user_email>xavi</user_email><created_at>1538467938</created_at></activity></activities><comments><comment><content><![CDATA[A comment on an issue]]></content><author>xavi</author><created_at>1538467997</created_at></comment></comments></issue></issues><methodologies></methodologies><categories><category><id>1</id><name>Issue description</name></category><category><id>2</id><name>Default category</name></category></categories><tags></tags></dradis-template>
+]]></text>
+      <activities>
+        <activity>
+          <action>create</action>
+          <user_email>xavi</user_email>
+          <created_at>1538467938</created_at>
+        </activity>
+      </activities>
+      <comments>
+        <comment>
+          <content><![CDATA[A comment on an issue]]></content>
+          <author>xavi</author>
+          <created_at>1538467997</created_at>
+        </comment>
+      </comments>
+    </issue>
+  </issues>
+  <methodologies/>
+  <categories>
+    <category>
+      <id>1</id>
+      <name>Issue description</name>
+    </category>
+    <category>
+      <id>2</id>
+      <name>Default category</name>
+    </category>
+  </categories>
+  <tags/>
+</dradis-template>

--- a/spec/lib/dradis/plugins/projects/export/v2/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/export/v2/template_spec.rb
@@ -12,9 +12,13 @@ describe Dradis::Plugins::Projects::Export::V2::Template do
   end
 
   context 'exporting a project' do
+    before do
+      node = create(:node, project: project)
+      issue = create(:issue, text: 'Issue 1', node: project.issue_library)
+    end
+
     context 'with comments in an issue' do
       before do
-        issue = create(:issue, text: 'Issue 1', node: project.issue_library)
         create(:comment, content: 'A comment on an issue', commentable: issue)
       end
 
@@ -25,13 +29,23 @@ describe Dradis::Plugins::Projects::Export::V2::Template do
 
     context 'with comments in a note' do
       before do
-        node = create(:node, project: project)
         note = create(:note, text: 'Note 1', node: node)
         create(:comment, content: 'A comment on a note', commentable: note)
       end
 
       it 'exports comments in the note' do
         expect(export).to include('A comment on a note')
+      end
+    end
+
+    context 'with comments in an evidence' do
+      before do
+        evidence = create(:evidence, text: 'Test evidence', node: node, issue: issue)
+        create(:comment, content: 'A comment on an evidence', commentable: evidence)
+      end
+
+      it 'exports comments in the evidence' do
+        expect(export).to include('A comment on an evidence')
       end
     end
   end

--- a/spec/lib/dradis/plugins/projects/upload/v2/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/upload/v2/template_spec.rb
@@ -25,14 +25,21 @@ describe Dradis::Plugins::Projects::Upload::V2::Template::Importer do
       importer.import(file: file_path)
     end
 
+    let(:node) { project.nodes.find_by(label: 'Node 1') }
+
     it 'imports comments in issues' do
       issue = project.issues.first
       expect(issue.comments.first.content).to include('A comment on an issue')
     end
 
     it 'imports comments in notes' do
-      note = project.nodes.find_by(label: 'Node 1').notes.first
+      note = node.notes.first
       expect(note.comments.first.content).to include('A comment on a note')
+    end
+
+    it 'imports comments in evidence' do
+      evidence = node.evidence.first
+      expect(evidence.comments.first.content).to include('A comment on an evidence')
     end
   end
 end


### PR DESCRIPTION
Reviewer notes: update the base branch when #35 is merged.

### Spec
Since we're adding comments to evidence, we also need to have a way to export and import them.

**Proposed solution**
When exporting, we need to build the comments when building the evidence in the file `Dradis::Plugins::Projects::Export::V1::Template`.

When importing, we parse the comments when importing the evidence in the file `Dradis::Plugins::Projects::Upload::V1::Template`.

### How to test

1. In a project add an evidence
2. Add comments to the evidence
3. Export the project and assert that the comments were added to the XML.
4. Import the exported project to an empty project
5. Assert that the comments were created.