### PR TITLE
Port boards IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Dradis Framework 3.15 (XXX, 2019) ##
 
 *  Fix upload with attachments
-*  Being able to export boards (v3)
+*  Being able to export/upload boards (v3)
 
 ## Dradis Framework 3.14 (August, 2019) ##
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Dradis Framework 3.15 (XXX, 2019) ##
 
 *  Fix upload with attachments
+*  Being able to export boards (v3)
 
 ## Dradis Framework 3.14 (August, 2019) ##
 

--- a/lib/dradis/plugins/projects/engine.rb
+++ b/lib/dradis/plugins/projects/engine.rb
@@ -19,7 +19,7 @@ module Dradis
         initializer "dradis-projects.set_configs" do |app|
           options = app.config.dradis.projects
           options.template_exporter ||= Dradis::Plugins::Projects::Export::V2::Template
-          options.template_uploader ||= Dradis::Plugins::Projects::Upload::V2::Template::Importer
+          options.template_uploader ||= Dradis::Plugins::Projects::Upload::V3::Template::Importer
         end
 
 

--- a/lib/dradis/plugins/projects/engine.rb
+++ b/lib/dradis/plugins/projects/engine.rb
@@ -18,7 +18,7 @@ module Dradis
 
         initializer "dradis-projects.set_configs" do |app|
           options = app.config.dradis.projects
-          options.template_exporter ||= Dradis::Plugins::Projects::Export::V2::Template
+          options.template_exporter ||= Dradis::Plugins::Projects::Export::V3::Template
           options.template_uploader ||= Dradis::Plugins::Projects::Upload::V3::Template::Importer
         end
 

--- a/lib/dradis/plugins/projects/export/template.rb
+++ b/lib/dradis/plugins/projects/export/template.rb
@@ -29,3 +29,4 @@ end
 
 require_relative 'v1/template'
 require_relative 'v2/template'
+require_relative 'v3/template'

--- a/lib/dradis/plugins/projects/export/v3/template.rb
+++ b/lib/dradis/plugins/projects/export/v3/template.rb
@@ -1,0 +1,57 @@
+module Dradis::Plugins::Projects::Export::V3
+  class Template < Dradis::Plugins::Projects::Export::V2::Template
+    VERSION = 3
+
+    protected
+
+    def build_methodologies(builder)
+      boards = content_service.all_boards
+
+      builder.methodologies do |methodologies_builder|
+
+        boards.each do |board|
+          node_id =
+            board.node == project.methodology_library ? nil : board.node_id
+
+          methodologies_builder.board(version: VERSION) do |board_builder|
+            board_builder.id(board.id)
+            board_builder.name(board.name)
+            board_builder.node_id(node_id)
+
+            board.ordered_items.each do |list|
+
+              board_builder.list do |list_builder|
+                list_builder.id(list.id)
+                list_builder.name(list.name)
+                list_builder.previous_id(list.previous_id)
+
+                list.ordered_items.each do |card|
+
+                  list_builder.card do |card_builder|
+                    card_builder.id(card.id)
+                    card_builder.name(card.name)
+                    card_builder.description do
+                      card_builder.cdata!(card.description)
+                    end
+                    card_builder.due_date(card.due_date)
+                    card_builder.previous_id(card.previous_id)
+
+                    card_builder.assignees do |assignee_builder|
+                      card.assignees.each do |assignee|
+                        assignee_builder.assignee(assignee.email)
+                      end
+                    end
+
+                    build_activities_for(card_builder, card)
+                    build_comments_for(card_builder, card)
+                  end
+
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dradis/plugins/projects/gem_version.rb
+++ b/lib/dradis/plugins/projects/gem_version.rb
@@ -8,9 +8,9 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 14
+        MINOR = 15
         TINY = 0
-        PRE = nil
+        PRE = 'rc1'
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
       end

--- a/lib/dradis/plugins/projects/upload/template.rb
+++ b/lib/dradis/plugins/projects/upload/template.rb
@@ -89,3 +89,4 @@ end
 
 require_relative 'v1/template'
 require_relative 'v2/template'
+require_relative 'v3/template'

--- a/lib/dradis/plugins/projects/upload/v3/template.rb
+++ b/lib/dradis/plugins/projects/upload/v3/template.rb
@@ -1,0 +1,203 @@
+module Dradis::Plugins::Projects::Upload::V3
+  module Template
+    class Importer < Dradis::Plugins::Projects::Upload::V2::Template::Importer
+      private
+
+      # Private: Given a XML node contianing assignee information this method
+      # tries to recreate the assignment in the new project.
+      #
+      #   * If the user exists in this instance: assign the card to that user
+      #     (no matter if the user is not a project author).
+      #   * If the user doesn't exist, don't creat an assiment and add a note
+      #     inside the card's description.
+      #
+      # card         - the Card object we're creating assignments for.
+      # xml_assignee - the Nokogiri::XML::Node that contains node assignment
+      #                information.
+      #
+      # Returns nothing, but creates a new Assignee for this card.
+      def create_assignee(card, xml_assignee)
+        email   = xml_assignee.text()
+        user_id = user_id_for_email(email)
+
+        if user_id == -1
+          old_assignee_field = card.fields['FormerAssignees'] || ''
+          card.set_field 'FormerAssignees', old_assignee_field << "* #{email}\n"
+        else
+          old_assignee_ids  = card.assignee_ids
+          card.assignee_ids = old_assignee_ids + [user_id]
+        end
+      end
+
+      # Private: Reassign cross-references once all the objects in the project
+      # have been recreated.
+      #
+      # No arguments received, but the methods relies on :lookup_table and
+      # :pending_changes provided by dradis-projects.
+      #
+      # Returns nothing.
+      def finalize_cards
+        logger.info { 'Reassigning card positions...' }
+
+        # Fix the :previous_id with the new card IDs
+        pending_changes[:cards].each do |card|
+          card.previous_id = lookup_table[:cards][card.previous_id]
+          raise "Couldn't save card's position" unless validate_and_save(card)
+        end
+
+        logger.info { 'Done.' }
+      end
+
+      # Private: Reassign the List's :previous_id now that we know what are the
+      # new IDs that correspond to all List objects in the import.
+      #
+      # No arguments received, but the method relies on :lookup_table and
+      # :pending_changes provided by dradis-projects.
+      #
+      # Returns nothing.
+      def finalize_lists
+        logger.info { 'Reassigning list positions...' }
+
+        # Fix the :previous_id with the new card IDs
+        pending_changes[:lists].each do |list|
+          list.previous_id = lookup_table[:lists][list.previous_id]
+          raise "Couldn't save list's position" unless validate_and_save(list)
+        end
+
+        logger.info { 'Done.' }
+      end
+
+      # Private: Restore Board, List and Card information from the project
+      # template.
+      def parse_methodologies(template)
+        if template_version == 1
+          # Restore Board from old xml methodology format
+          process_v1_methodologies(template)
+        else
+          process_v2_methodologies(template)
+        end
+      end
+
+      # Private:  For each XML card block, we're creating a new Card instance,
+      # restoring the card's Activities and Assignments.
+      #
+      # list     - the List instance that will hold this Card.
+      # xml_card - the Nokogiri::XML node containing the card's data.
+      #
+      # Returns nothing, but makes use of the :lookup_table and :pending_changes
+      # variables to store information that will be used during the
+      # :finalize_cards method.
+      def process_card(list, xml_card)
+        due_date = xml_card.at_xpath('due_date').text
+        due_date = Date.iso8601(due_date) unless due_date.empty?
+
+        card = list.cards.create name: xml_card.at_xpath('name').text,
+          description: xml_card.at_xpath('description').text,
+          due_date: due_date,
+          previous_id: xml_card.at_xpath('previous_id').text
+
+        xml_card.xpath('activities/activity').each do |xml_activity|
+          raise "Couldn't create activity for Card ##{card.id}" unless create_activity(card, xml_activity)
+        end
+
+        xml_card.xpath('assignees/assignee').each do |xml_assignee|
+         raise "Couldn't create assignment for Card ##{card.id}" unless create_assignee(card, xml_assignee)
+        end
+
+        raise "Couldn't create comments for Card ##{card.id}" unless create_comments(card, xml_card.xpath('comments/comment'))
+
+        lookup_table[:cards][xml_card.at_xpath('id').text.to_i] = card.id
+        pending_changes[:cards] << card
+      end
+
+      # Private: Initial pass over ./methodologies/ section of the tempalte
+      # document to extract Board, List and Card information. Some of the
+      # objects will contain invalid references (e.g. the former :previous_id
+      # of a card will need to be reassigned) that we will fix at a later stage.
+      #
+      # template - A Nokogiri::XML document containing the project template
+      #            data.
+      #
+      # Returns nothing.
+      def process_methodologies(template)
+        logger.info { 'Processing Methodologies...' }
+
+        lookup_table[:cards]    = {}
+        lookup_table[:lists]    = {}
+        pending_changes[:cards] = []
+        pending_changes[:lists] = []
+
+        template.xpath('dradis-template/methodologies/board').each do |xml_board|
+          xml_node_id = xml_board.at_xpath('node_id').try(:text)
+          node_id =
+            if xml_node_id.present?
+              lookup_table[:nodes][xml_node_id]
+            else
+              project.methodology_library.id
+            end
+
+          board = content_service.create_board(
+            name: xml_board.at_xpath('name').text,
+            node_id: node_id
+          )
+
+          xml_board.xpath('./list').each do |xml_list|
+            list = board.lists.create name: xml_list.at_xpath('name').text,
+              previous_id: xml_list.at_xpath('previous_id').text
+
+            lookup_table[:lists][xml_list.at_xpath('id').text.to_i] = list.id
+            pending_changes[:lists] << list
+
+            xml_list.xpath('./card').each do |xml_card|
+              process_card(list, xml_card)
+            end
+          end
+        end
+
+        logger.info { 'Done.' }
+      end
+
+      # Private: Pass over old ./methodologies/ sections of the template
+      # document to extract Board, List and Card information.
+      #
+      # template - A Nokogiri::XML document containing the project template
+      #            data.
+      #
+      # Returns nothing.
+      def process_v1_methodologies(template)
+        xml_methodologies = template.xpath('dradis-template/methodologies/methodology')
+        return if xml_methodologies.empty?
+
+        logger.info { 'Processing V1 Methodologies...' }
+
+        migration = MethodologyMigrationService.new(project.id)
+
+        xml_methodologies.each do |xml_methodology|
+          migration.migrate(
+            Methodology.new(content: xml_methodology.at_xpath('text').text)
+          )
+        end
+
+        logger.info { 'Done.' }
+      end
+
+      # Private: Pass over new ./methodologies/ sections of the template
+      # document to extract Board, List and Card information.
+      #
+      # template - A Nokogiri::XML document containing the project template
+      #            data.
+      #
+      # Returns nothing.
+      def process_v2_methodologies(template)
+        # Restore Board
+        process_methodologies(template)
+
+        # Reassign Card's :previous_id and :assginees
+        finalize_cards()
+
+        # Reassign List's :previous id
+        finalize_lists()
+      end
+    end
+  end
+end

--- a/lib/dradis/plugins/projects/upload/v3/template.rb
+++ b/lib/dradis/plugins/projects/upload/v3/template.rb
@@ -138,8 +138,7 @@ module Dradis::Plugins::Projects::Upload::V3
 
           board = content_service.create_board(
             name: xml_board.at_xpath('name').text,
-            node_id: node_id,
-            project: project
+            node_id: node_id
           )
 
           xml_board.xpath('./list').each do |xml_list|

--- a/lib/dradis/plugins/projects/upload/v3/template.rb
+++ b/lib/dradis/plugins/projects/upload/v3/template.rb
@@ -138,7 +138,8 @@ module Dradis::Plugins::Projects::Upload::V3
 
           board = content_service.create_board(
             name: xml_board.at_xpath('name').text,
-            node_id: node_id
+            node_id: node_id,
+            project: project
           )
 
           xml_board.xpath('./list').each do |xml_list|


### PR DESCRIPTION
Spec

When importing as a package or template, we should be accepting the new <board> format in the imported xml, or the old <methodologies> format


How to test

Importing
- Import an old template and package files, with methodologies still not using boards
- After import we should have a methodology ready to be migrated into a board /check project summary page)
- Import an new template and package files, with methodologies using boards
- After import we should have a boards when we click on Methodologies in the sidebar

Exporting
- Create a board with lists and a tasks
- Export the project as a template and as package using the web
- Assert that in the exported xml files (also the one inside the zip), we see the exported boards as
- <methodologies><board version="3">...</board></methodologies>
- Export the project as a template and as package using command line and check the same.

