### PR TITLE
Remove rc versioning

### DIFF
--- a/lib/dradis/plugins/projects/gem_version.rb
+++ b/lib/dradis/plugins/projects/gem_version.rb
@@ -8,9 +8,9 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 15
+        MINOR = 14
         TINY = 0
-        PRE = 'rc1'
+        PRE = ''
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
       end


### PR DESCRIPTION
We will not be version bumping the non-tagged master changes until we release v1.15.0.
As per new version bumping guidelines. Master may contain code that is between versions.