### PR TITLE
Always upload old style and new style methodologies

### DIFF
--- a/lib/dradis/plugins/projects/upload/v3/template.rb
+++ b/lib/dradis/plugins/projects/upload/v3/template.rb
@@ -70,12 +70,11 @@ module Dradis::Plugins::Projects::Upload::V3
       # Private: Restore Board, List and Card information from the project
       # template.
       def parse_methodologies(template)
-        if template_version == 1
-          # Restore Board from old xml methodology format
-          process_v1_methodologies(template)
-        else
-          process_v2_methodologies(template)
-        end
+        # old methodologies format
+        process_v1_methodologies(template)
+
+        # new methodologies format
+        process_v2_methodologies(template)
       end
 
       # Private:  For each XML card block, we're creating a new Card instance,


### PR DESCRIPTION
### Spec
In CE we exported old methodologies with `version = 2`
In Pro we exported new methodologies with `version = 2`

We cannot check the template version to know how to upload methodologies.
We can just check which methodologies come with the file to upload and upload them.

### How to test
Old files (version = 2) containing new or old methodologies, must upload the methodologies correctly both in Pro and CE