### PR TITLE
Fix deleted author for comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Gemfile.lock
 
 # Gem artifacts
 /pkg/
+
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.20 (XXX, 2020) ##
+
+*  Fix exporting projects with comments by deleted users.
+
 ## Dradis Framework 3.19 (September, 2020) ##
 
 *  No changes

--- a/lib/dradis/plugins/projects/export/v2/template.rb
+++ b/lib/dradis/plugins/projects/export/v2/template.rb
@@ -11,7 +11,7 @@ module Dradis::Plugins::Projects::Export::V2
             comment_builder.content do
               comment_builder.cdata!(comment.content)
             end
-            comment_builder.author(comment.user.email)
+            comment_builder.author(comment.user&.email)
             comment_builder.created_at(comment.created_at.to_i)
           end
         end

--- a/lib/dradis/plugins/projects/gem_version.rb
+++ b/lib/dradis/plugins/projects/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 19
+        MINOR = 20
         TINY = 0
         PRE = nil
 

--- a/lib/dradis/plugins/projects/upload/v2/template.rb
+++ b/lib/dradis/plugins/projects/upload/v2/template.rb
@@ -13,17 +13,26 @@ module Dradis::Plugins::Projects::Upload::V2
             commentable_type: commentable.class.to_s,
             content: xml_comment.at_xpath('content').text,
             created_at: Time.at(xml_comment.at_xpath('created_at').text.to_i),
-            user_id: user_id_for_email(author_email)
+            user_id: user_id_for_comments(author_email)
           )
 
-          if comment.user.email != author_email
+          if comment.user.nil?
             comment.content = comment.content +
               "\n\nOriginal author not available in this Dradis instance: "\
               "#{author_email}."
           end
 
-          return false unless validate_and_save(comment)
+          unless validate_and_save(comment)
+            logger.info { "comment errors: #{comment.inspect}" }
+            return false
+          end
         end
+      end
+
+      def user_id_for_comments(author_email)
+        user_id_for_email(author_email)
+
+        @users[author_email] || nil
       end
     end
   end

--- a/lib/dradis/plugins/projects/upload/v2/template.rb
+++ b/lib/dradis/plugins/projects/upload/v2/template.rb
@@ -32,7 +32,7 @@ module Dradis::Plugins::Projects::Upload::V2
       def user_id_for_comments(author_email)
         user_id_for_email(author_email)
 
-        @users[author_email] || nil
+        @users[author_email]
       end
     end
   end

--- a/spec/fixtures/files/with_comments.xml
+++ b/spec/fixtures/files/with_comments.xml
@@ -71,7 +71,7 @@ A
   </nodes>
   <issues>
     <issue>
-      <id>1</id>
+      <id>586</id>
       <author>xavi</author>
       <text><![CDATA[#[Title]#
 Issue 1

--- a/spec/lib/dradis/plugins/projects/export/v2/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/export/v2/template_spec.rb
@@ -13,13 +13,13 @@ describe Dradis::Plugins::Projects::Export::V2::Template do
 
   context 'exporting a project' do
     before do
-      node = create(:node, project: project)
-      issue = create(:issue, text: 'Issue 1', node: project.issue_library)
+      @node = create(:node, project: project)
+      @issue = create(:issue, text: 'Issue 1', node: project.issue_library)
     end
 
     context 'with comments in an issue' do
       before do
-        create(:comment, content: 'A comment on an issue', commentable: issue)
+        create(:comment, content: 'A comment on an issue', commentable: @issue)
       end
 
       it 'exports comments in the issue' do
@@ -29,7 +29,7 @@ describe Dradis::Plugins::Projects::Export::V2::Template do
 
     context 'with comments in a note' do
       before do
-        note = create(:note, text: 'Note 1', node: node)
+        note = create(:note, text: 'Note 1', node: @node)
         create(:comment, content: 'A comment on a note', commentable: note)
       end
 
@@ -40,12 +40,24 @@ describe Dradis::Plugins::Projects::Export::V2::Template do
 
     context 'with comments in an evidence' do
       before do
-        evidence = create(:evidence, text: 'Test evidence', node: node, issue: issue)
+        evidence = create(:evidence, content: 'Test evidence', node: @node, issue: @issue)
         create(:comment, content: 'A comment on an evidence', commentable: evidence)
       end
 
       it 'exports comments in the evidence' do
         expect(export).to include('A comment on an evidence')
+      end
+    end
+
+    context 'with comments with a deleted author' do
+      before do
+        note = create(:note, text: 'Note 1', node: @node)
+        comment = create(:comment, content: 'Deleted user', commentable: note)
+        comment.update_attribute :user, nil
+      end
+
+      it 'exports the comment without errors' do
+        expect(export).to include('Deleted user')
       end
     end
   end

--- a/spec/lib/dradis/plugins/projects/upload/v2/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/upload/v2/template_spec.rb
@@ -41,5 +41,17 @@ describe Dradis::Plugins::Projects::Upload::V2::Template::Importer do
       evidence = node.evidence.first
       expect(evidence.comments.first.content).to include('A comment on an evidence')
     end
+
+    it 'imports comments without user' do
+      issue = project.issues.first
+      note = node.notes.first
+      evidence = node.evidence.first
+
+      aggregate_failures do
+        expect(issue.comments.first.user).to be_nil
+        expect(note.comments.first.user).to be_nil
+        expect(evidence.comments.first.user).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
### Spec
Currently, an export error is thrown when exporting a project with a comment by a deleted user.

Error: 
```
bundler: failed to load command: thor (/opt/dradispro/dradispro/releases/202008020007/vendor/bundle/ruby/2.4.0/bin/thor)
NoMethodError: undefined method `email' for nil:NilClass
  /opt/dradispro/dradispro/shared/bundle/ruby/2.4.0/gems/dradis-projects-3.18.0/lib/dradis/plugins/projects/export/v2/template.rb:14:in `block (3 levels) in build_comments_for'
```

**Proposed solution**
Handle nil users when exporting comments. The exported author attribute for those comments will now be blank.

### How to test
Setup the project:
1. As an admin, create a project and an issue in the project.
2. Create a temporary user. Assign this user to the project
3. Login as the temporary user and comment on the issue
4. Login as an admin and delete the temporary user.
5. Test exporting the project and confirm that an error is thrown.

Test the fix:
1. Pull the dradis-projects branch
2. Point the Gemfile to your local installation of dradis-projects
3. Run bundle install and restart the server
4. Export the project we created and confirm that the project exports correctly.