### PR TITLE
Export::Template - push the Board conversion XML to the model

### DIFF
--- a/lib/dradis/plugins/projects/export/v3/template.rb
+++ b/lib/dradis/plugins/projects/export/v3/template.rb
@@ -13,7 +13,7 @@ module Dradis::Plugins::Projects::Export::V3
           node_id =
             board.node == project.methodology_library ? nil : board.node_id
 
-          board.to_template(methodologies_builder, includes: [:activities, :assignees, :comments], version: VERSION)
+          board.to_xml(methodologies_builder, includes: [:activities, :assignees, :comments], version: VERSION)
         end
       end
     end

--- a/lib/dradis/plugins/projects/export/v3/template.rb
+++ b/lib/dradis/plugins/projects/export/v3/template.rb
@@ -13,43 +13,7 @@ module Dradis::Plugins::Projects::Export::V3
           node_id =
             board.node == project.methodology_library ? nil : board.node_id
 
-          methodologies_builder.board(version: VERSION) do |board_builder|
-            board_builder.id(board.id)
-            board_builder.name(board.name)
-            board_builder.node_id(node_id)
-
-            board.ordered_items.each do |list|
-
-              board_builder.list do |list_builder|
-                list_builder.id(list.id)
-                list_builder.name(list.name)
-                list_builder.previous_id(list.previous_id)
-
-                list.ordered_items.each do |card|
-
-                  list_builder.card do |card_builder|
-                    card_builder.id(card.id)
-                    card_builder.name(card.name)
-                    card_builder.description do
-                      card_builder.cdata!(card.description)
-                    end
-                    card_builder.due_date(card.due_date)
-                    card_builder.previous_id(card.previous_id)
-
-                    card_builder.assignees do |assignee_builder|
-                      card.assignees.each do |assignee|
-                        assignee_builder.assignee(assignee.email)
-                      end
-                    end
-
-                    build_activities_for(card_builder, card)
-                    build_comments_for(card_builder, card)
-                  end
-
-                end
-              end
-            end
-          end
+          board.to_template(methodologies_builder, includes: [:activities, :assignees, :comments], version: VERSION)
         end
       end
     end


### PR DESCRIPTION
Instead of having Template know how to build the Board XML representation, push that down to the Board class itself.

See: https://github.com/dradis/dradis-ce/pull/797