### PR TITLE
Fix node parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+[v#.#.#] ([month] [YYYY])
+  - [future tense verb] [feature]
+  - Upgraded gems:
+    - [gem]
+  - Bugs fixes:
+    - [future tense verb] [bug fix]
+    - Bug tracker items:
+      - [item]
+  - Security Fixes:
+    - High: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+    - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+    - Low: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+
 v4.1.2.1 (December 2021)
   - Security Fixes:
     - High: Authenticated author path traversal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - [gem]
   - Bugs fixes:
     - [future tense verb] [bug fix]
+    - Fixes missing parent nodes during template and package imports
     - Bug tracker items:
       - [item]
   - Security Fixes:

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -380,7 +380,7 @@ module Dradis::Plugins::Projects::Upload::V1
 
             new_taggable_id = case taggable_type
                               when 'Note'
-                                lookup_table[:issues][old_taggable_id]
+                                lookup_table[:issues][old_taggable_id.to_i]
                               end
 
             Tagging.create! tag: tag,

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -332,7 +332,7 @@ module Dradis::Plugins::Projects::Upload::V1
 
           if xml_note.at_xpath('author') != nil
             old_id = xml_note.at_xpath('category-id').text.strip
-            new_id = lookup_table[:categories][old_id]
+            new_id = lookup_table[:categories][old_id.to_i]
 
             created_at = xml_note.at_xpath('created-at')
             updated_at = xml_note.at_xpath('updated-at')

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -118,7 +118,7 @@ module Dradis::Plugins::Projects::Upload::V1
       def finalize_evidence
         pending_changes[:evidence].each_with_index do |evidence, i|
           logger.info { "Setting issue_id for evidence" }
-          evidence.issue_id = lookup_table[:issues][evidence.issue_id.to_s]
+          evidence.issue_id = lookup_table[:issues][evidence.issue_id]
 
           new_content = evidence.content.gsub(ATTACHMENT_URL) do |_|
             "!%s/projects/%d/nodes/%d/attachments/%s!" % [$1, project.id, lookup_table[:nodes][$2.to_i], $3]

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -141,7 +141,7 @@ module Dradis::Plugins::Projects::Upload::V1
       def finalize_nodes
         pending_changes[:orphan_nodes].each do |node|
           logger.info { "Finding parent for orphaned node: #{node.label}. Former parent was #{node.parent_id}" }
-          node.parent_id = lookup_table[:nodes][node.parent_id.to_s]
+          node.parent_id = lookup_table[:nodes][node.parent_id]
           raise "Couldn't save node parent for Node ##{node.id}" unless validate_and_save(node)
         end
       end

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -153,7 +153,7 @@ module Dradis::Plugins::Projects::Upload::V1
         logger.info { 'Processing Categories...' }
 
         template.xpath('dradis-template/categories/category').each do |xml_category|
-          old_id   = xml_category.at_xpath('id').text.strip
+          old_id   = Integer(xml_category.at_xpath('id').text.strip)
           name     = xml_category.at_xpath('name').text.strip
           category = nil
 
@@ -183,7 +183,7 @@ module Dradis::Plugins::Projects::Upload::V1
             pending_changes[:attachment_notes] << issue
           end
 
-          old_id = xml_issue.at_xpath('id').text.strip
+          old_id = Integer(xml_issue.at_xpath('id').text.strip)
           lookup_table[:issues][old_id] = issue.id
           logger.info{ "New issue detected: #{issue.title}" }
         end

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -331,8 +331,8 @@ module Dradis::Plugins::Projects::Upload::V1
         xml_node.xpath('notes/note').each do |xml_note|
 
           if xml_note.at_xpath('author') != nil
-            old_id = xml_note.at_xpath('category-id').text.strip
-            new_id = lookup_table[:categories][old_id.to_i]
+            old_id = Integer(xml_note.at_xpath('category-id').text.strip)
+            new_id = lookup_table[:categories][old_id]
 
             created_at = xml_note.at_xpath('created-at')
             updated_at = xml_note.at_xpath('updated-at')
@@ -375,12 +375,12 @@ module Dradis::Plugins::Projects::Upload::V1
           logger.info { "New tag detected: #{name}" }
 
           xml_tag.xpath('./taggings/tagging').each do |xml_tagging|
-            old_taggable_id = xml_tagging.at_xpath('taggable-id').text()
+            old_taggable_id = Integer(xml_tagging.at_xpath('taggable-id').text())
             taggable_type   = xml_tagging.at_xpath('taggable-type').text()
 
             new_taggable_id = case taggable_type
                               when 'Note'
-                                lookup_table[:issues][old_taggable_id.to_i]
+                                lookup_table[:issues][old_taggable_id]
                               end
 
             Tagging.create! tag: tag,

--- a/lib/dradis/plugins/projects/upload/v3/template.rb
+++ b/lib/dradis/plugins/projects/upload/v3/template.rb
@@ -41,7 +41,7 @@ module Dradis::Plugins::Projects::Upload::V3
 
         # Fix the :previous_id with the new card IDs
         pending_changes[:cards].each do |card|
-          card.previous_id = lookup_table[:cards][card.previous_id]
+          card.previous_id = lookup_table[:cards][card.previous_id.to_i]
           raise "Couldn't save card's position" unless validate_and_save(card)
         end
 

--- a/lib/dradis/plugins/projects/upload/v3/template.rb
+++ b/lib/dradis/plugins/projects/upload/v3/template.rb
@@ -94,7 +94,7 @@ module Dradis::Plugins::Projects::Upload::V3
         card = list.cards.create name: xml_card.at_xpath('name').text,
           description: xml_card.at_xpath('description').text,
           due_date: due_date,
-          previous_id: Integer(xml_card.at_xpath('previous_id').text)
+          previous_id: xml_card.at_xpath('previous_id').text&.to_i
 
         xml_card.xpath('activities/activity').each do |xml_activity|
           raise "Couldn't create activity for Card ##{card.id}" unless create_activity(card, xml_activity)
@@ -106,8 +106,8 @@ module Dradis::Plugins::Projects::Upload::V3
 
         raise "Couldn't create comments for Card ##{card.id}" unless create_comments(card, xml_card.xpath('comments/comment'))
 
-        old_id = Integer(xml_card.at_xpath('id').text)
-        lookup_table[:cards][old_id] = card.id
+        xml_id = Integer(xml_card.at_xpath('id').text)
+        lookup_table[:cards][xml_id] = card.id
         pending_changes[:cards] << card
       end
 
@@ -129,10 +129,10 @@ module Dradis::Plugins::Projects::Upload::V3
         pending_changes[:lists] = []
 
         template.xpath('dradis-template/methodologies/board').each do |xml_board|
-          xml_node_id = Integer(xml_board.at_xpath('node_id').try(:text))
+          xml_node_id = xml_board.at_xpath('node_id').try(:text)
           node_id =
             if xml_node_id.present?
-              lookup_table[:nodes][xml_node_id]
+              lookup_table[:nodes][xml_node_id.to_i]
             else
               project.methodology_library.id
             end
@@ -144,7 +144,7 @@ module Dradis::Plugins::Projects::Upload::V3
 
           xml_board.xpath('./list').each do |xml_list|
             list = board.lists.create name: xml_list.at_xpath('name').text,
-              previous_id: Integer(xml_list.at_xpath('previous_id').text)
+              previous_id: xml_list.at_xpath('previous_id').text&.to_i
             xml_id = Integer(xml_list.at_xpath('id').text)
 
             lookup_table[:lists][xml_id] = list.id

--- a/lib/dradis/plugins/projects/upload/v3/template.rb
+++ b/lib/dradis/plugins/projects/upload/v3/template.rb
@@ -60,7 +60,7 @@ module Dradis::Plugins::Projects::Upload::V3
 
         # Fix the :previous_id with the new card IDs
         pending_changes[:lists].each do |list|
-          list.previous_id = lookup_table[:lists][list.previous_id]
+          list.previous_id = lookup_table[:lists][list.previous_id].to_i
           raise "Couldn't save list's position" unless validate_and_save(list)
         end
 
@@ -94,7 +94,7 @@ module Dradis::Plugins::Projects::Upload::V3
         card = list.cards.create name: xml_card.at_xpath('name').text,
           description: xml_card.at_xpath('description').text,
           due_date: due_date,
-          previous_id: xml_card.at_xpath('previous_id').text
+          previous_id: xml_card.at_xpath('previous_id').text.to_i
 
         xml_card.xpath('activities/activity').each do |xml_activity|
           raise "Couldn't create activity for Card ##{card.id}" unless create_activity(card, xml_activity)
@@ -143,7 +143,7 @@ module Dradis::Plugins::Projects::Upload::V3
 
           xml_board.xpath('./list').each do |xml_list|
             list = board.lists.create name: xml_list.at_xpath('name').text,
-              previous_id: xml_list.at_xpath('previous_id').text
+              previous_id: xml_list.at_xpath('previous_id').text.to_i
 
             lookup_table[:lists][xml_list.at_xpath('id').text.to_i] = list.id
             pending_changes[:lists] << list

--- a/lib/dradis/plugins/projects/upload/v3/template.rb
+++ b/lib/dradis/plugins/projects/upload/v3/template.rb
@@ -41,7 +41,7 @@ module Dradis::Plugins::Projects::Upload::V3
 
         # Fix the :previous_id with the new card IDs
         pending_changes[:cards].each do |card|
-          card.previous_id = lookup_table[:cards][card.previous_id.to_i]
+          card.previous_id = lookup_table[:cards][card.previous_id]
           raise "Couldn't save card's position" unless validate_and_save(card)
         end
 
@@ -60,7 +60,7 @@ module Dradis::Plugins::Projects::Upload::V3
 
         # Fix the :previous_id with the new card IDs
         pending_changes[:lists].each do |list|
-          list.previous_id = lookup_table[:lists][list.previous_id].to_i
+          list.previous_id = lookup_table[:lists][list.previous_id]
           raise "Couldn't save list's position" unless validate_and_save(list)
         end
 
@@ -94,7 +94,7 @@ module Dradis::Plugins::Projects::Upload::V3
         card = list.cards.create name: xml_card.at_xpath('name').text,
           description: xml_card.at_xpath('description').text,
           due_date: due_date,
-          previous_id: xml_card.at_xpath('previous_id').text.to_i
+          previous_id: Integer(xml_card.at_xpath('previous_id').text)
 
         xml_card.xpath('activities/activity').each do |xml_activity|
           raise "Couldn't create activity for Card ##{card.id}" unless create_activity(card, xml_activity)
@@ -106,7 +106,8 @@ module Dradis::Plugins::Projects::Upload::V3
 
         raise "Couldn't create comments for Card ##{card.id}" unless create_comments(card, xml_card.xpath('comments/comment'))
 
-        lookup_table[:cards][xml_card.at_xpath('id').text.to_i] = card.id
+        old_id = Integer(xml_card.at_xpath('id').text)
+        lookup_table[:cards][old_id] = card.id
         pending_changes[:cards] << card
       end
 
@@ -128,10 +129,10 @@ module Dradis::Plugins::Projects::Upload::V3
         pending_changes[:lists] = []
 
         template.xpath('dradis-template/methodologies/board').each do |xml_board|
-          xml_node_id = xml_board.at_xpath('node_id').try(:text)
+          xml_node_id = Integer(xml_board.at_xpath('node_id').try(:text))
           node_id =
             if xml_node_id.present?
-              lookup_table[:nodes][xml_node_id.to_i]
+              lookup_table[:nodes][xml_node_id]
             else
               project.methodology_library.id
             end
@@ -143,9 +144,10 @@ module Dradis::Plugins::Projects::Upload::V3
 
           xml_board.xpath('./list').each do |xml_list|
             list = board.lists.create name: xml_list.at_xpath('name').text,
-              previous_id: xml_list.at_xpath('previous_id').text.to_i
+              previous_id: Integer(xml_list.at_xpath('previous_id').text)
+            old_id = Integer(xml_list.at_xpath('id').text)
 
-            lookup_table[:lists][xml_list.at_xpath('id').text.to_i] = list.id
+            lookup_table[:lists][old_id] = list.id
             pending_changes[:lists] << list
 
             xml_list.xpath('./card').each do |xml_card|

--- a/lib/dradis/plugins/projects/upload/v3/template.rb
+++ b/lib/dradis/plugins/projects/upload/v3/template.rb
@@ -145,9 +145,9 @@ module Dradis::Plugins::Projects::Upload::V3
           xml_board.xpath('./list').each do |xml_list|
             list = board.lists.create name: xml_list.at_xpath('name').text,
               previous_id: Integer(xml_list.at_xpath('previous_id').text)
-            old_id = Integer(xml_list.at_xpath('id').text)
+            xml_id = Integer(xml_list.at_xpath('id').text)
 
-            lookup_table[:lists][old_id] = list.id
+            lookup_table[:lists][xml_id] = list.id
             pending_changes[:lists] << list
 
             xml_list.xpath('./card').each do |xml_card|


### PR DESCRIPTION
## Spec
Since the last release when a project package or template is imported it is no longer nesting nodes appropriately. It orphans all nodes to the root level.

# Solution

Use integers in places integers should not be strings. This is achieved in two ways. Cast with an error using `Integer()` where we always expect an int. In the event a nil value is also valid (previous_id) use `to_i`