### PR TITLE
Catch missing nodes for attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
     - [gem]
   - Bugs fixes:
     - [future tense verb] [bug fix]
-    - Fixes missing parent nodes during template and package imports
-    - Fixes missing nodes for attachments during template and package imports
+    - Fixed missing parent nodes during template and package imports
+    - Fixed missing nodes for attachments during template and package imports
     - Bug tracker items:
       - [item]
   - Security Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - Bugs fixes:
     - [future tense verb] [bug fix]
     - Fixes missing parent nodes during template and package imports
+    - Fixes missing nodes for attachments during template and package imports
     - Bug tracker items:
       - [item]
   - Security Fixes:

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -104,8 +104,13 @@ module Dradis::Plugins::Projects::Upload::V1
 
           logger.info { "Adjusting screenshot URLs: #{item.class.name} ##{item.id}" }
 
-          new_text = item.send(text_attr).gsub(ATTACHMENT_URL) do |_|
-            "!%s/projects/%d/nodes/%d/attachments/%s!" % [$1, project.id, lookup_table[:nodes][$2.to_i] || $2.to_i, $3]
+          new_text = item.send(text_attr).gsub(ATTACHMENT_URL) do |attachment|
+            if lookup_table[:nodes][$2.to_i]
+              "!%s/projects/%d/nodes/%d/attachments/%s!" % [$1, project.id, lookup_table[:nodes][$2.to_i], $3]
+            else
+              logger.error { "Invalid attachment found: #{attachment}" }
+              attachment
+            end
           end
           item.send(text_attr.to_s + "=", new_text)
 
@@ -120,8 +125,13 @@ module Dradis::Plugins::Projects::Upload::V1
           logger.info { "Setting issue_id for evidence" }
           evidence.issue_id = lookup_table[:issues][evidence.issue_id]
 
-          new_content = evidence.content.gsub(ATTACHMENT_URL) do |_|
-            "!%s/projects/%d/nodes/%d/attachments/%s!" % [$1, project.id, lookup_table[:nodes][$2.to_i] || $2.to_i, $3]
+          new_content = evidence.content.gsub(ATTACHMENT_URL) do |attachment|
+            if lookup_table[:nodes][$2.to_i]
+              "!%s/projects/%d/nodes/%d/attachments/%s!" % [$1, project.id, lookup_table[:nodes][$2.to_i], $3]
+            else
+              logger.error { "Invalid attachment found: #{attachment}" }
+              attachment
+            end
           end
           evidence.content = new_content
 

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -400,7 +400,7 @@ module Dradis::Plugins::Projects::Upload::V1
           if node_id
             "!%s/projects/%d/nodes/%d/attachments/%s!" % [$1, project.id, node_id, $3]
           else
-            logger.error { "Invalid attachment found: #{attachment}" }
+            logger.error { "The attachment wasn't included in the package: #{attachment}" }
             attachment
           end
         end

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -105,7 +105,7 @@ module Dradis::Plugins::Projects::Upload::V1
           logger.info { "Adjusting screenshot URLs: #{item.class.name} ##{item.id}" }
 
           new_text = item.send(text_attr).gsub(ATTACHMENT_URL) do |_|
-            "!%s/projects/%d/nodes/%d/attachments/%s!" % [$1, project.id, lookup_table[:nodes][$2.to_i], $3]
+            "!%s/projects/%d/nodes/%d/attachments/%s!" % [$1, project.id, lookup_table[:nodes][$2.to_i] || $2.to_i, $3]
           end
           item.send(text_attr.to_s + "=", new_text)
 
@@ -121,7 +121,7 @@ module Dradis::Plugins::Projects::Upload::V1
           evidence.issue_id = lookup_table[:issues][evidence.issue_id]
 
           new_content = evidence.content.gsub(ATTACHMENT_URL) do |_|
-            "!%s/projects/%d/nodes/%d/attachments/%s!" % [$1, project.id, lookup_table[:nodes][$2.to_i], $3]
+            "!%s/projects/%d/nodes/%d/attachments/%s!" % [$1, project.id, lookup_table[:nodes][$2.to_i] || $2.to_i, $3]
           end
           evidence.content = new_content
 

--- a/spec/fixtures/files/missing_node.xml
+++ b/spec/fixtures/files/missing_node.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dradis-template version="2">
+<nodes><node><id>5</id><label>Uploaded files</label><parent-id/><position>0</position><properties><![CDATA[{}]]></properties><type-id>0</type-id><notes></notes><evidence></evidence><activities></activities></node></nodes>
+<issues><issue><id>2</id><author>admin@securityroots.com</author><text><![CDATA[#[Title]#
+Test Issue
+
+#[Description]#
+!/pro/projects/222/nodes/12345/attachments/hello.jpg!
+
+  ]]></text><activities></activities><comments></comments></issue></issues>
+</dradis-template>

--- a/spec/lib/dradis/plugins/projects/upload/v1/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/upload/v1/template_spec.rb
@@ -48,4 +48,29 @@ describe Dradis::Plugins::Projects::Upload::V1::Template::Importer do
       expect(importer.import(file: file_path)).to be false
     end
   end
+
+  context 'uploading a template with attachment but missing node' do
+    let(:file_path) do
+      File.join(File.dirname(__FILE__), '../../../../../../', 'fixtures', 'files', 'missing_node.xml')
+    end
+
+    it 'does not modify the attachment' do
+      logger = double('logger')
+      allow(logger).to receive_messages(debug: nil, error: nil, fatal: nil, info: nil)
+      expect(logger).to receive(:error).once
+
+      importer = importer_class::Importer.new(
+        default_user_id: user.id,
+        logger: logger,
+        plugin: importer_class,
+        project_id: project.id
+      )
+
+      importer.import(file: file_path)
+
+      expect(project.issues.first.text).to include(
+        "!/pro/projects/222/nodes/12345/attachments/hello.jpg!"
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Spec
When uploading a project export with a reference to an attachment that is from a deleted node, the following error is thrown:

```
> [09:39:34] Setting issue_id for evidence
> [09:39:34] can't convert nil into Integer
> [09:39:34] Worker process completed.
```

The error is thrown from ruby String's % method. In the line:
```
"!%s/projects/%d/nodes/%d/attachments/%s!" % [$1, project.id, lookup_table[:nodes][$2.to_i], $3]
```
nodes/%d expects a number coming from the lookup_table. But if the node isn't present in the table, it returns `nil` and the can't convert nil into Integer error is thrown. A simple example would be:
```
'%d' % nil
```
throwing the same error.

**Proposed solution**
Catch the case when the node_id from the attachment is not found in the lookup table.