### PR TITLE
Provide upload mapping options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+v4.3.0 ([month] 2022)
+  - Provide plugin template mappings (no mappings)
+  - Upgraded gems:
+    - [gem]
+  - Bugs fixes:
+    - [future tense verb] [bug fix]
+    - Bug tracker items:
+      - [item]
+  - Security Fixes:
+    - High: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+    - Medium: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+    - Low: (Authenticated|Unauthenticated) (admin|author|contributor) [vulnerability description]
+
 v4.2.0 (February 2022)
   - Bugs fixes:
     - Fix missing nodes for attachments during template and package imports

--- a/lib/dradis/plugins/projects/engine.rb
+++ b/lib/dradis/plugins/projects/engine.rb
@@ -34,6 +34,13 @@ module Dradis
             Dradis::Plugins::Projects::Upload::Template
           ]
         end
+
+        def self.template_names
+          {
+            Dradis::Plugins::Projects::Upload::Package => {},
+            Dradis::Plugins::Projects::Upload::Template => {}
+          }
+        end
       end
     end
   end

--- a/lib/dradis/plugins/projects/engine.rb
+++ b/lib/dradis/plugins/projects/engine.rb
@@ -34,13 +34,6 @@ module Dradis
             Dradis::Plugins::Projects::Upload::Template
           ]
         end
-
-        def self.template_names
-          {
-            Dradis::Plugins::Projects::Upload::Package => {},
-            Dradis::Plugins::Projects::Upload::Template => {}
-          }
-        end
       end
     end
   end

--- a/lib/dradis/plugins/projects/upload/package.rb
+++ b/lib/dradis/plugins/projects/upload/package.rb
@@ -12,6 +12,9 @@ module Dradis::Plugins::Projects::Upload
     # In this module you will find the implementation details that enable you to
     # upload a project archive (generated using ProjectExport::Processor::full_project)
     class Importer < Dradis::Plugins::Upload::Importer
+      def self.templates
+        { }
+      end
 
       def import(params={})
         package = params[:file]

--- a/lib/dradis/plugins/projects/upload/template.rb
+++ b/lib/dradis/plugins/projects/upload/template.rb
@@ -12,6 +12,10 @@ module Dradis::Plugins::Projects::Upload
     class Importer < Dradis::Plugins::Upload::Importer
       attr_accessor :lookup_table, :template_version
 
+      def self.templates
+        { }
+      end
+
       # The import method is invoked by the framework to process a template file
       # that has just been uploaded using the 'Import from file...' dialog.
       #


### PR DESCRIPTION
Provide no-op plugin mappings. We just need to ensure the plugin registers both template, and package options.