### PR TITLE
QA import/export projects

### DIFF
--- a/dradis-projects.gemspec
+++ b/dradis-projects.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'combustion'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec'
 
   spec.add_dependency 'dradis-plugins', '~> 4.0'

--- a/lib/dradis/plugins/projects/engine.rb
+++ b/lib/dradis/plugins/projects/engine.rb
@@ -19,7 +19,7 @@ module Dradis
         initializer "dradis-projects.set_configs" do |app|
           options = app.config.dradis.projects
           options.template_exporter ||= Dradis::Plugins::Projects::Export::V4::Template
-          options.template_uploader ||= Dradis::Plugins::Projects::Upload::V3::Template::Importer
+          options.template_uploader ||= Dradis::Plugins::Projects::Upload::V4::Template::Importer
         end
 
 

--- a/lib/dradis/plugins/projects/engine.rb
+++ b/lib/dradis/plugins/projects/engine.rb
@@ -18,7 +18,7 @@ module Dradis
 
         initializer "dradis-projects.set_configs" do |app|
           options = app.config.dradis.projects
-          options.template_exporter ||= Dradis::Plugins::Projects::Export::V3::Template
+          options.template_exporter ||= Dradis::Plugins::Projects::Export::V4::Template
           options.template_uploader ||= Dradis::Plugins::Projects::Upload::V3::Template::Importer
         end
 

--- a/lib/dradis/plugins/projects/export/template.rb
+++ b/lib/dradis/plugins/projects/export/template.rb
@@ -27,6 +27,4 @@ module Dradis::Plugins::Projects::Export
   end
 end
 
-require_relative 'v1/template'
-require_relative 'v2/template'
-require_relative 'v3/template'
+require_relative 'v4/template'

--- a/lib/dradis/plugins/projects/export/v1/template.rb
+++ b/lib/dradis/plugins/projects/export/v1/template.rb
@@ -3,7 +3,7 @@
 # V1 can be removed on Apr 2024
 #
 # We're duplicating this file for v4, and even though the code lives in two
-# places now, this file isn't expected to evolved and is now frozen to V1
+# places now, this file isn't expected to evolve and is now frozen to V1
 # behavior.
 
 module Dradis::Plugins::Projects::Export::V1

--- a/lib/dradis/plugins/projects/export/v2/template.rb
+++ b/lib/dradis/plugins/projects/export/v2/template.rb
@@ -1,3 +1,11 @@
+# DEPRECATED - this class is v2 of the Template Exporter and shouldn't be updated.
+# V4 released on Apr 2022
+# V2 can be removed on Apr 2024
+#
+# We're duplicating this file for v4, and even though the code lives in two
+# places now, this file isn't expected to evolved and is now frozen to V2
+# behavior.
+
 module Dradis::Plugins::Projects::Export::V2
   class Template < Dradis::Plugins::Projects::Export::V1::Template
     VERSION = 2

--- a/lib/dradis/plugins/projects/export/v2/template.rb
+++ b/lib/dradis/plugins/projects/export/v2/template.rb
@@ -3,7 +3,7 @@
 # V2 can be removed on Apr 2024
 #
 # We're duplicating this file for v4, and even though the code lives in two
-# places now, this file isn't expected to evolved and is now frozen to V2
+# places now, this file isn't expected to evolve and is now frozen to V2
 # behavior.
 
 module Dradis::Plugins::Projects::Export::V2

--- a/lib/dradis/plugins/projects/export/v3/template.rb
+++ b/lib/dradis/plugins/projects/export/v3/template.rb
@@ -1,3 +1,11 @@
+# DEPRECATED - this class is v3 of the Template Exporter and shouldn't be updated.
+# V4 released on Apr 2022
+# V3 can be removed on Apr 2024
+#
+# We're duplicating this file for v4, and even though the code lives in two
+# places now, this file isn't expected to evolved and is now frozen to V3
+# behavior.
+
 module Dradis::Plugins::Projects::Export::V3
   class Template < Dradis::Plugins::Projects::Export::V2::Template
     VERSION = 3

--- a/lib/dradis/plugins/projects/export/v3/template.rb
+++ b/lib/dradis/plugins/projects/export/v3/template.rb
@@ -3,7 +3,7 @@
 # V3 can be removed on Apr 2024
 #
 # We're duplicating this file for v4, and even though the code lives in two
-# places now, this file isn't expected to evolved and is now frozen to V3
+# places now, this file isn't expected to evolve and is now frozen to V3
 # behavior.
 
 module Dradis::Plugins::Projects::Export::V3

--- a/lib/dradis/plugins/projects/export/v4/template.rb
+++ b/lib/dradis/plugins/projects/export/v4/template.rb
@@ -33,9 +33,6 @@ module Dradis::Plugins::Projects::Export::V4
       end
     end
 
-    # No-op here, overwritten in V2
-    def build_comments_for(builder, commentable); end
-
     def build_evidence_for_node(builder, node)
       builder.evidence do |evidences_builder|
         node.evidence.each do |evidence|
@@ -128,9 +125,6 @@ module Dradis::Plugins::Projects::Export::V4
         end
       end
     end
-
-    # No-op here, overwritten in PRO
-    def build_report_content(builder); end
 
     def build_tags(builder)
       tags = project.tags

--- a/lib/dradis/plugins/projects/upload/template.rb
+++ b/lib/dradis/plugins/projects/upload/template.rb
@@ -91,6 +91,4 @@ module Dradis::Plugins::Projects::Upload
   end
 end
 
-require_relative 'v1/template'
-require_relative 'v2/template'
-require_relative 'v3/template'
+require_relative 'v4/template'

--- a/lib/dradis/plugins/projects/upload/template.rb
+++ b/lib/dradis/plugins/projects/upload/template.rb
@@ -33,7 +33,6 @@ module Dradis::Plugins::Projects::Upload
       # table to re-associate the attachments in the project archive with the new
       # node IDs in the current project.
       def import(params={})
-
         # load the template
         logger.info { "Loading template file from: #{params[:file]}" }
         template = Nokogiri::XML(File.read(params[:file]))
@@ -43,6 +42,7 @@ module Dradis::Plugins::Projects::Upload
           logger.error { "Invalid project template format." }
           return false
         end
+
 
         if template.xpath('/dradis-template').empty?
           error = "The uploaded file doesn't look like a Dradis project template (/dradis-template)."

--- a/lib/dradis/plugins/projects/upload/v1/template.rb
+++ b/lib/dradis/plugins/projects/upload/v1/template.rb
@@ -3,7 +3,7 @@
 # V1 can be removed on Apr 2024
 #
 # We're duplicating this file for v4, and even though the code lives in two
-# places now, this file isn't expected to evolved and is now frozen to V1
+# places now, this file isn't expected to evolve and is now frozen to V1
 # behavior.
 
 module Dradis::Plugins::Projects::Upload::V1

--- a/lib/dradis/plugins/projects/upload/v2/template.rb
+++ b/lib/dradis/plugins/projects/upload/v2/template.rb
@@ -1,3 +1,11 @@
+# DEPRECATED - this class is v2 of the Template Importer and shouldn't be updated.
+# V4 released on Apr 2022
+# V2 can be removed on Apr 2024
+#
+# We're duplicating this file for v4, and even though the code lives in two
+# places now, this file isn't expected to evolved and is now frozen to V2
+# behavior.
+
 module Dradis::Plugins::Projects::Upload::V2
   module Template
     class Importer < Dradis::Plugins::Projects::Upload::V1::Template::Importer

--- a/lib/dradis/plugins/projects/upload/v2/template.rb
+++ b/lib/dradis/plugins/projects/upload/v2/template.rb
@@ -3,7 +3,7 @@
 # V2 can be removed on Apr 2024
 #
 # We're duplicating this file for v4, and even though the code lives in two
-# places now, this file isn't expected to evolved and is now frozen to V2
+# places now, this file isn't expected to evolve and is now frozen to V2
 # behavior.
 
 module Dradis::Plugins::Projects::Upload::V2

--- a/lib/dradis/plugins/projects/upload/v3/template.rb
+++ b/lib/dradis/plugins/projects/upload/v3/template.rb
@@ -1,3 +1,11 @@
+# DEPRECATED - this class is v3 of the Template Importer and shouldn't be updated.
+# V4 released on Apr 2022
+# V3 can be removed on Apr 2024
+#
+# We're duplicating this file for v4, and even though the code lives in two
+# places now, this file isn't expected to evolved and is now frozen to V3
+# behavior.
+
 module Dradis::Plugins::Projects::Upload::V3
   module Template
     class Importer < Dradis::Plugins::Projects::Upload::V2::Template::Importer

--- a/lib/dradis/plugins/projects/upload/v3/template.rb
+++ b/lib/dradis/plugins/projects/upload/v3/template.rb
@@ -3,7 +3,7 @@
 # V3 can be removed on Apr 2024
 #
 # We're duplicating this file for v4, and even though the code lives in two
-# places now, this file isn't expected to evolved and is now frozen to V3
+# places now, this file isn't expected to evolve and is now frozen to V3
 # behavior.
 
 module Dradis::Plugins::Projects::Upload::V3

--- a/lib/dradis/plugins/projects/upload/v4/template.rb
+++ b/lib/dradis/plugins/projects/upload/v4/template.rb
@@ -1,14 +1,5 @@
-# DEPRECATED - this class is v1 of the Template Importer and shouldn't be updated.
-# V4 released on Apr 2022
-# V1 can be removed on Apr 2024
-#
-# We're duplicating this file for v4, and even though the code lives in two
-# places now, this file isn't expected to evolved and is now frozen to V1
-# behavior.
-
-module Dradis::Plugins::Projects::Upload::V1
+module Dradis::Plugins::Projects::Upload::V4
   module Template
-
     class Importer < Dradis::Plugins::Projects::Upload::Template::Importer
 
       attr_accessor :attachment_notes, :logger, :pending_changes, :users
@@ -47,9 +38,30 @@ module Dradis::Plugins::Projects::Upload::V1
 
       private
 
-      # No-op here, overwritten in V2
       def create_comments(commentable, xml_comments)
-        true
+        return true if xml_comments.empty?
+
+        xml_comments.each do |xml_comment|
+          author_email = xml_comment.at_xpath('author').text
+          comment = Comment.new(
+            commentable_id: commentable.id,
+            commentable_type: commentable.class.to_s,
+            content: xml_comment.at_xpath('content').text,
+            created_at: Time.at(xml_comment.at_xpath('created_at').text.to_i),
+            user_id: users[author_email]
+          )
+
+          if comment.user.nil?
+            comment.content = comment.content +
+              "\n\nOriginal author not available in this Dradis instance: "\
+              "#{author_email}."
+          end
+
+          unless validate_and_save(comment)
+            logger.info { "comment errors: #{comment.inspect}" }
+            return false
+          end
+        end
       end
 
       def create_activities(trackable, xml_trackable)
@@ -77,6 +89,7 @@ module Dradis::Plugins::Projects::Upload::V1
         # TODO: Need to find some way of checking for dups
         # May be combination of text, category_id and created_at
         issue.author   = xml_issue.at_xpath('author').text.strip
+        issue.state     = xml_issue.at_xpath('state').text
         issue.text     = xml_issue.at_xpath('text').text
         issue.node     = project.issue_library
         issue.category = Category.issue
@@ -435,7 +448,204 @@ module Dradis::Plugins::Projects::Upload::V1
           return false
         end
       end
-    end
 
+      # Private: Given a XML node contianing assignee information this method
+      # tries to recreate the assignment in the new project.
+      #
+      #   * If the user exists in this instance: assign the card to that user
+      #     (no matter if the user is not a project author).
+      #   * If the user doesn't exist, don't creat an assiment and add a note
+      #     inside the card's description.
+      #
+      # card         - the Card object we're creating assignments for.
+      # xml_assignee - the Nokogiri::XML::Node that contains node assignment
+      #                information.
+      #
+      # Returns nothing, but creates a new Assignee for this card.
+      def create_assignee(card, xml_assignee)
+        email   = xml_assignee.text()
+        user_id = user_id_for_email(email)
+
+        if user_id == -1
+          old_assignee_field = card.fields['FormerAssignees'] || ''
+          card.set_field 'FormerAssignees', old_assignee_field << "* #{email}\n"
+        else
+          old_assignee_ids  = card.assignee_ids
+          card.assignee_ids = old_assignee_ids + [user_id]
+        end
+      end
+
+      # Private: Reassign cross-references once all the objects in the project
+      # have been recreated.
+      #
+      # No arguments received, but the methods relies on :lookup_table and
+      # :pending_changes provided by dradis-projects.
+      #
+      # Returns nothing.
+      def finalize_cards
+        logger.info { 'Reassigning card positions...' }
+
+        # Fix the :previous_id with the new card IDs
+        pending_changes[:cards].each do |card|
+          card.previous_id = lookup_table[:cards][card.previous_id]
+          raise "Couldn't save card's position" unless validate_and_save(card)
+        end
+
+        logger.info { 'Done.' }
+      end
+
+      # Private: Reassign the List's :previous_id now that we know what are the
+      # new IDs that correspond to all List objects in the import.
+      #
+      # No arguments received, but the method relies on :lookup_table and
+      # :pending_changes provided by dradis-projects.
+      #
+      # Returns nothing.
+      def finalize_lists
+        logger.info { 'Reassigning list positions...' }
+
+        # Fix the :previous_id with the new card IDs
+        pending_changes[:lists].each do |list|
+          list.previous_id = lookup_table[:lists][list.previous_id]
+          raise "Couldn't save list's position" unless validate_and_save(list)
+        end
+
+        logger.info { 'Done.' }
+      end
+
+      # Private: Restore Board, List and Card information from the project
+      # template.
+      def parse_methodologies(template)
+        if template_version == 1
+          # Restore Board from old xml methodology format
+          process_v1_methodologies(template)
+        else
+          process_v2_methodologies(template)
+        end
+      end
+
+      # Private:  For each XML card block, we're creating a new Card instance,
+      # restoring the card's Activities and Assignments.
+      #
+      # list     - the List instance that will hold this Card.
+      # xml_card - the Nokogiri::XML node containing the card's data.
+      #
+      # Returns nothing, but makes use of the :lookup_table and :pending_changes
+      # variables to store information that will be used during the
+      # :finalize_cards method.
+      def process_card(list, xml_card)
+        due_date = xml_card.at_xpath('due_date').text
+        due_date = Date.iso8601(due_date) unless due_date.empty?
+
+        card = list.cards.create name: xml_card.at_xpath('name').text,
+          description: xml_card.at_xpath('description').text,
+          due_date: due_date,
+          previous_id: xml_card.at_xpath('previous_id').text&.to_i
+
+        xml_card.xpath('activities/activity').each do |xml_activity|
+          raise "Couldn't create activity for Card ##{card.id}" unless create_activity(card, xml_activity)
+        end
+
+        xml_card.xpath('assignees/assignee').each do |xml_assignee|
+         raise "Couldn't create assignment for Card ##{card.id}" unless create_assignee(card, xml_assignee)
+        end
+
+        raise "Couldn't create comments for Card ##{card.id}" unless create_comments(card, xml_card.xpath('comments/comment'))
+
+        xml_id = Integer(xml_card.at_xpath('id').text)
+        lookup_table[:cards][xml_id] = card.id
+        pending_changes[:cards] << card
+      end
+
+      # Private: Initial pass over ./methodologies/ section of the tempalte
+      # document to extract Board, List and Card information. Some of the
+      # objects will contain invalid references (e.g. the former :previous_id
+      # of a card will need to be reassigned) that we will fix at a later stage.
+      #
+      # template - A Nokogiri::XML document containing the project template
+      #            data.
+      #
+      # Returns nothing.
+      def process_methodologies(template)
+        logger.info { 'Processing Methodologies...' }
+
+        lookup_table[:cards]    = {}
+        lookup_table[:lists]    = {}
+        pending_changes[:cards] = []
+        pending_changes[:lists] = []
+
+        template.xpath('dradis-template/methodologies/board').each do |xml_board|
+          xml_node_id = xml_board.at_xpath('node_id').try(:text)
+          node_id =
+            if xml_node_id.present?
+              lookup_table[:nodes][xml_node_id.to_i]
+            else
+              project.methodology_library.id
+            end
+
+          board = content_service.create_board(
+            name: xml_board.at_xpath('name').text,
+            node_id: node_id
+          )
+
+          xml_board.xpath('./list').each do |xml_list|
+            list = board.lists.create name: xml_list.at_xpath('name').text,
+              previous_id: xml_list.at_xpath('previous_id').text&.to_i
+            xml_id = Integer(xml_list.at_xpath('id').text)
+
+            lookup_table[:lists][xml_id] = list.id
+            pending_changes[:lists] << list
+
+            xml_list.xpath('./card').each do |xml_card|
+              process_card(list, xml_card)
+            end
+          end
+        end
+
+        logger.info { 'Done.' }
+      end
+
+      # Private: Pass over old ./methodologies/ sections of the template
+      # document to extract Board, List and Card information.
+      #
+      # template - A Nokogiri::XML document containing the project template
+      #            data.
+      #
+      # Returns nothing.
+      def process_v1_methodologies(template)
+        xml_methodologies = template.xpath('dradis-template/methodologies/methodology')
+        return if xml_methodologies.empty?
+
+        logger.info { 'Processing V1 Methodologies...' }
+
+        migration = MethodologyMigrationService.new(project.id)
+
+        xml_methodologies.each do |xml_methodology|
+          migration.migrate(
+            Methodology.new(content: xml_methodology.at_xpath('text').text)
+          )
+        end
+
+        logger.info { 'Done.' }
+      end
+
+      # Private: Pass over new ./methodologies/ sections of the template
+      # document to extract Board, List and Card information.
+      #
+      # template - A Nokogiri::XML document containing the project template
+      #            data.
+      #
+      # Returns nothing.
+      def process_v2_methodologies(template)
+        # Restore Board
+        process_methodologies(template)
+
+        # Reassign Card's :previous_id and :assginees
+        finalize_cards()
+
+        # Reassign List's :previous id
+        finalize_lists()
+      end
+    end
   end
 end

--- a/lib/dradis/plugins/projects/upload/v4/template.rb
+++ b/lib/dradis/plugins/projects/upload/v4/template.rb
@@ -89,7 +89,7 @@ module Dradis::Plugins::Projects::Upload::V4
         # TODO: Need to find some way of checking for dups
         # May be combination of text, category_id and created_at
         issue.author   = xml_issue.at_xpath('author').text.strip
-        issue.state    = xml_issue.at_xpath('state')&.text || 'draft'
+        issue.state    = xml_issue.at_xpath('state')&.text || :published
         issue.text     = xml_issue.at_xpath('text').text
         issue.node     = project.issue_library
         issue.category = Category.issue

--- a/lib/dradis/plugins/projects/upload/v4/template.rb
+++ b/lib/dradis/plugins/projects/upload/v4/template.rb
@@ -89,7 +89,7 @@ module Dradis::Plugins::Projects::Upload::V4
         # TODO: Need to find some way of checking for dups
         # May be combination of text, category_id and created_at
         issue.author   = xml_issue.at_xpath('author').text.strip
-        issue.state     = xml_issue.at_xpath('state').text
+        issue.state    = xml_issue.at_xpath('state')&.text || 'draft'
         issue.text     = xml_issue.at_xpath('text').text
         issue.node     = project.issue_library
         issue.category = Category.issue

--- a/spec/fixtures/files/with_invalid_states.xml
+++ b/spec/fixtures/files/with_invalid_states.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dradis-template version="4">
+  <nodes>
+    <node>
+      <id>3</id>
+      <label>Node 1</label>
+      <parent-id/>
+      <position>0</position>
+      <properties><![CDATA[{
+}]]></properties>
+      <type-id>1</type-id>
+      <notes>
+        <note>
+          <id>2</id>
+          <author>xavi</author>
+          <category-id>2</category-id>
+          <text><![CDATA[#[Title]#
+Note 1
+
+#[Description]#
+
+]]></text>
+          <activities>
+            <activity>
+              <action>create</action>
+              <user_email>xavi</user_email>
+              <created_at>1538467955</created_at>
+            </activity>
+          </activities>
+          <comments>
+            <comment>
+              <content><![CDATA[A comment on a note]]></content>
+              <author>xavi</author>
+              <created_at>1538467968</created_at>
+            </comment>
+          </comments>
+        </note>
+      </notes>
+      <evidence>
+        <evidence>
+          <id>386</id>
+          <author>xavi</author>
+          <issue-id>586</issue-id>
+          <content><![CDATA[#[Location]#
+A
+]]></content>
+          <activities>
+            <activity>
+              <action>create</action>
+              <user_email>xavi</user_email>
+              <created_at>1538549260</created_at>
+            </activity>
+          </activities>
+          <comments>
+            <comment>
+              <content><![CDATA[A comment on an evidence]]></content>
+              <author>xavi</author>
+              <created_at>1538549286</created_at>
+            </comment>
+          </comments>
+        </evidence>
+      </evidence>
+      <activities>
+        <activity>
+          <action>create</action>
+          <user_email>xavi</user_email>
+          <created_at>1538467945</created_at>
+        </activity>
+      </activities>
+    </node>
+  </nodes>
+  <issues>
+    <issue>
+      <id>586</id>
+      <author>xavi</author>
+      <state>fakestate</state>
+      <text><![CDATA[#[Title]#
+Issue 1
+
+#[Description]#
+
+]]></text>
+      <activities>
+        <activity>
+          <action>create</action>
+          <user_email>xavi</user_email>
+          <created_at>1538467938</created_at>
+        </activity>
+      </activities>
+      <comments>
+        <comment>
+          <content><![CDATA[A comment on an issue]]></content>
+          <author>xavi</author>
+          <created_at>1538467997</created_at>
+        </comment>
+      </comments>
+    </issue>
+  </issues>
+  <methodologies/>
+  <categories>
+    <category>
+      <id>1</id>
+      <name>Issue description</name>
+    </category>
+    <category>
+      <id>2</id>
+      <name>Default category</name>
+    </category>
+  </categories>
+  <tags/>
+</dradis-template>

--- a/spec/fixtures/files/with_states.xml
+++ b/spec/fixtures/files/with_states.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dradis-template version="4">
+  <nodes>
+    <node>
+      <id>3</id>
+      <label>Node 1</label>
+      <parent-id/>
+      <position>0</position>
+      <properties><![CDATA[{
+}]]></properties>
+      <type-id>1</type-id>
+      <notes>
+        <note>
+          <id>2</id>
+          <author>xavi</author>
+          <category-id>2</category-id>
+          <text><![CDATA[#[Title]#
+Note 1
+
+#[Description]#
+
+]]></text>
+          <activities>
+            <activity>
+              <action>create</action>
+              <user_email>xavi</user_email>
+              <created_at>1538467955</created_at>
+            </activity>
+          </activities>
+          <comments>
+            <comment>
+              <content><![CDATA[A comment on a note]]></content>
+              <author>xavi</author>
+              <created_at>1538467968</created_at>
+            </comment>
+          </comments>
+        </note>
+      </notes>
+      <evidence>
+        <evidence>
+          <id>386</id>
+          <author>xavi</author>
+          <issue-id>586</issue-id>
+          <content><![CDATA[#[Location]#
+A
+]]></content>
+          <activities>
+            <activity>
+              <action>create</action>
+              <user_email>xavi</user_email>
+              <created_at>1538549260</created_at>
+            </activity>
+          </activities>
+          <comments>
+            <comment>
+              <content><![CDATA[A comment on an evidence]]></content>
+              <author>xavi</author>
+              <created_at>1538549286</created_at>
+            </comment>
+          </comments>
+        </evidence>
+      </evidence>
+      <activities>
+        <activity>
+          <action>create</action>
+          <user_email>xavi</user_email>
+          <created_at>1538467945</created_at>
+        </activity>
+      </activities>
+    </node>
+  </nodes>
+  <issues>
+    <issue>
+      <id>586</id>
+      <author>xavi</author>
+      <state>ready_for_review</state>
+      <text><![CDATA[#[Title]#
+Issue 1
+
+#[Description]#
+
+]]></text>
+      <activities>
+        <activity>
+          <action>create</action>
+          <user_email>xavi</user_email>
+          <created_at>1538467938</created_at>
+        </activity>
+      </activities>
+      <comments>
+        <comment>
+          <content><![CDATA[A comment on an issue]]></content>
+          <author>xavi</author>
+          <created_at>1538467997</created_at>
+        </comment>
+      </comments>
+    </issue>
+  </issues>
+  <methodologies/>
+  <categories>
+    <category>
+      <id>1</id>
+      <name>Issue description</name>
+    </category>
+    <category>
+      <id>2</id>
+      <name>Default category</name>
+    </category>
+  </categories>
+  <tags/>
+</dradis-template>

--- a/spec/lib/dradis/plugins/projects/export/v2/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/export/v2/template_spec.rb
@@ -3,7 +3,7 @@
 # V2 can be removed on Apr 2024
 #
 # We're duplicating this file for v4, and even though the code lives in two
-# places now, this file isn't expected to evolved and is now frozen to V2
+# places now, this file isn't expected to evolve and is now frozen to V2
 # behavior.
 
 require 'rails_helper'

--- a/spec/lib/dradis/plugins/projects/export/v2/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/export/v2/template_spec.rb
@@ -1,6 +1,14 @@
+# DEPRECATED - this class is v2 of the Template Importer and shouldn't be updated.
+# V4 released on Apr 2022
+# V2 can be removed on Apr 2024
+#
+# We're duplicating this file for v4, and even though the code lives in two
+# places now, this file isn't expected to evolved and is now frozen to V2
+# behavior.
+
 require 'rails_helper'
 
-describe Dradis::Plugins::Projects::Export::V2::Template do
+describe 'Dradis::Plugins::Projects::Export::V2::Template' do
   let(:project) { create(:project) }
   let(:user) { create(:user) }
   let(:export) do

--- a/spec/lib/dradis/plugins/projects/export/v4/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/export/v4/template_spec.rb
@@ -1,0 +1,84 @@
+# Run the spec in CE/Pro context with:
+# rspec <relative path to dradis-projects>/spec/lib/dradis/plugins/projects/export/v4/template_spec.rb
+
+require 'rails_helper'
+
+describe 'Dradis::Plugins::Projects::Export::V4::Template' do
+  let(:project) { create(:project) }
+  let(:user) { create(:user) }
+  let(:exporter) { 'Dradis::Plugins::Projects::Export::V4::Template' }
+  let(:export) do
+    exporter.constantize.new(
+      default_user_id: user.id,
+      plugin: Dradis::Plugins::Projects,
+      project_id: project.id
+    ).export
+  end
+
+  context 'exporting a project' do
+    before do
+      @node = create(:node, project: project)
+      @issue = create(:issue, text: 'Issue 1', node: project.issue_library)
+    end
+
+    describe 'comments' do
+      context 'with comments in an issue' do
+        before do
+          create(:comment, content: 'A comment on an issue', commentable: @issue)
+        end
+
+        it 'exports comments in the issue' do
+          expect(export).to include('A comment on an issue')
+        end
+      end
+
+      context 'with comments in a note' do
+        before do
+          note = create(:note, text: 'Note 1', node: @node)
+          create(:comment, content: 'A comment on a note', commentable: note)
+        end
+
+        it 'exports comments in the note' do
+          expect(export).to include('A comment on a note')
+        end
+      end
+
+      context 'with comments in an evidence' do
+        before do
+          evidence = create(:evidence, content: 'Test evidence', node: @node, issue: @issue)
+          create(:comment, content: 'A comment on an evidence', commentable: evidence)
+        end
+
+        it 'exports comments in the evidence' do
+          expect(export).to include('A comment on an evidence')
+        end
+      end
+
+      context 'with comments with a deleted author' do
+        before do
+          note = create(:note, text: 'Note 1', node: @node)
+          comment = create(:comment, content: 'Deleted user', commentable: note)
+          comment.update_attribute :user, nil
+        end
+
+        it 'exports the comment without errors' do
+          expect(export).to include('Deleted user')
+        end
+      end
+    end
+
+    describe 'states' do
+      before do
+        Issue.states.each do |state|
+          create(:issue, text: 'Issue 1', node: project.issue_library, state: state[0])
+        end
+      end
+
+      it 'export issues with states' do
+        Issue.states.each do |state|
+          expect(export).to include("<state>#{state[0]}</state>")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/dradis/plugins/projects/upload/v1/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/upload/v1/template_spec.rb
@@ -1,3 +1,11 @@
+# DEPRECATED - this class is v1 of the Template Importer and shouldn't be updated.
+# V4 released on Apr 2022
+# V1 can be removed on Apr 2024
+#
+# We're duplicating this file for v4, and even though the code lives in two
+# places now, this file isn't expected to evolved and is now frozen to V1
+# behavior.
+
 # frozen_string_literal: true
 
 require 'rails_helper'

--- a/spec/lib/dradis/plugins/projects/upload/v1/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/upload/v1/template_spec.rb
@@ -3,7 +3,7 @@
 # V1 can be removed on Apr 2024
 #
 # We're duplicating this file for v4, and even though the code lives in two
-# places now, this file isn't expected to evolved and is now frozen to V1
+# places now, this file isn't expected to evolve and is now frozen to V1
 # behavior.
 
 # frozen_string_literal: true

--- a/spec/lib/dradis/plugins/projects/upload/v2/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/upload/v2/template_spec.rb
@@ -3,7 +3,7 @@
 # V2 can be removed on Apr 2024
 #
 # We're duplicating this file for v4, and even though the code lives in two
-# places now, this file isn't expected to evolved and is now frozen to V2
+# places now, this file isn't expected to evolve and is now frozen to V2
 # behavior.
 
 require 'rails_helper'

--- a/spec/lib/dradis/plugins/projects/upload/v2/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/upload/v2/template_spec.rb
@@ -1,6 +1,14 @@
+# DEPRECATED - this class is v2 of the Template Importer and shouldn't be updated.
+# V4 released on Apr 2022
+# V2 can be removed on Apr 2024
+#
+# We're duplicating this file for v4, and even though the code lives in two
+# places now, this file isn't expected to evolved and is now frozen to V2
+# behavior.
+
 require 'rails_helper'
 
-describe Dradis::Plugins::Projects::Upload::V2::Template::Importer do
+describe 'Dradis::Plugins::Projects::Upload::V2::Template::Importer' do
   let(:project) { create(:project) }
   let(:user) { create(:user) }
   let(:importer_class) { Dradis::Plugins::Projects::Upload::Template }

--- a/spec/lib/dradis/plugins/projects/upload/v4/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/upload/v4/template_spec.rb
@@ -1,0 +1,156 @@
+require 'rails_helper'
+
+describe 'Dradis::Plugins::Projects::Upload::V4::Template::Importer' do
+  let(:project) { create(:project) }
+  let(:user) { create(:user) }
+  let(:importer_class) { Dradis::Plugins::Projects::Upload::Template }
+
+  context 'uploading a template with attachments url' do
+    let(:file_path) do
+      File.join(File.dirname(__FILE__), '../../../../../../', 'fixtures', 'files', 'attachments_url.xml')
+    end
+
+    it 'converts the urls' do
+      importer = importer_class::Importer.new(
+        default_user_id: user.id,
+        plugin: importer_class,
+        project_id: project.id
+      )
+
+      importer.import(file: file_path)
+
+      p_id = project.id
+      n_id = project.plugin_uploads_node.id
+
+      expect(project.issues.first.text).to include(
+        "!/pro/projects/#{p_id}/nodes/#{n_id}/attachments/hello.jpg!\n\n" +
+        "!/projects/#{p_id}/nodes/#{n_id}/attachments/hello.jpg!\n\n" +
+        "!/pro/projects/#{p_id}/nodes/#{n_id}/attachments/hello.jpg!\n\n" +
+        "!/projects/#{p_id}/nodes/#{n_id}/attachments/hello.jpg!"
+      )
+    end
+  end
+
+  context 'uploading a template malformed paths as ids' do
+    let(:file_path) do
+      File.join(File.dirname(__FILE__), '../../../../../../', 'fixtures', 'files', 'malformed_ids.xml')
+    end
+
+    it 'returns false' do
+      importer = importer_class::Importer.new(
+        default_user_id: user.id,
+        plugin: importer_class,
+        project_id: project.id
+      )
+
+      expect(importer.import(file: file_path)).to be false
+    end
+  end
+
+  context 'uploading a template with attachment but missing node' do
+    let(:file_path) do
+      File.join(File.dirname(__FILE__), '../../../../../../', 'fixtures', 'files', 'missing_node.xml')
+    end
+
+    it 'does not modify the attachment' do
+      logger = double('logger')
+      allow(logger).to receive_messages(debug: nil, error: nil, fatal: nil, info: nil)
+      expect(logger).to receive(:error).once
+
+      importer = importer_class::Importer.new(
+        default_user_id: user.id,
+        logger: logger,
+        plugin: importer_class,
+        project_id: project.id
+      )
+
+      importer.import(file: file_path)
+
+      expect(project.issues.first.text).to include(
+        "!/pro/projects/222/nodes/12345/attachments/hello.jpg!"
+      )
+    end
+  end
+
+  context 'uploading a template with comments' do
+    let(:file_path) do
+      File.join(
+        File.dirname(__FILE__),
+        '../../../../../../',
+        'fixtures',
+        'files',
+        'with_comments.xml'
+      )
+    end
+
+    before do
+      importer = importer_class::Importer.new(
+        default_user_id: user.id,
+        plugin: importer_class,
+        project_id: project.id
+      )
+
+      importer.import(file: file_path)
+    end
+
+    let(:node) { project.nodes.find_by(label: 'Node 1') }
+
+    it 'imports comments in issues' do
+      issue = project.issues.first
+      expect(issue.comments.first.content).to include('A comment on an issue')
+    end
+
+    it 'imports comments in notes' do
+      note = node.notes.first
+      expect(note.comments.first.content).to include('A comment on a note')
+    end
+
+    it 'imports comments in evidence' do
+      evidence = node.evidence.first
+      expect(evidence.comments.first.content).to include('A comment on an evidence')
+    end
+
+    it 'imports comments without user' do
+      issue = project.issues.first
+      note = node.notes.first
+      evidence = node.evidence.first
+
+      aggregate_failures do
+        expect(issue.comments.first.user).to be_nil
+        expect(note.comments.first.user).to be_nil
+        expect(evidence.comments.first.user).to be_nil
+      end
+    end
+  end
+
+
+  describe 'states' do
+    let(:dir) do
+      File.join(File.dirname(__FILE__), '../../../../../../', 'fixtures', 'files')
+    end
+
+    before do
+      @importer = importer_class::Importer.new(
+        default_user_id: user.id,
+        plugin: importer_class,
+        project_id: project.id
+      )
+    end
+
+    context 'uploading a template with states' do
+      it 'imports issues with states from the template' do
+        @importer.import(file: File.join(dir, 'with_states.xml'))
+        issue = project.issues.first
+        expect(issue.state).to eq('ready_for_review')
+      end
+    end
+
+    context 'uploading a template without states' do
+      it 'imports issues with the draft state' do
+        @importer.import(file: File.join(dir, 'with_comments.xml'))
+        issue = project.issues.first
+        expect(issue.state).to eq('draft')
+      end
+    end
+  end
+end

--- a/spec/lib/dradis/plugins/projects/upload/v4/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/upload/v4/template_spec.rb
@@ -1,3 +1,6 @@
+# Run the spec in CE/Pro context with:
+# rspec <relative path to dradis-projects>/spec/lib/dradis/plugins/projects/upload/v4/template_spec.rb
+
 require 'rails_helper'
 
 describe 'Dradis::Plugins::Projects::Upload::V4::Template::Importer' do

--- a/spec/lib/dradis/plugins/projects/upload/v4/template_spec.rb
+++ b/spec/lib/dradis/plugins/projects/upload/v4/template_spec.rb
@@ -140,19 +140,28 @@ describe 'Dradis::Plugins::Projects::Upload::V4::Template::Importer' do
       )
     end
 
-    context 'uploading a template with states' do
-      it 'imports issues with states from the template' do
-        @importer.import(file: File.join(dir, 'with_states.xml'))
+    context 'uploading a template without states' do
+      it 'imports issues with the published state' do
+        @importer.import(file: File.join(dir, 'with_comments.xml'))
         issue = project.issues.first
-        expect(issue.state).to eq('ready_for_review')
+        expect(issue.state).to eq('published')
       end
     end
 
-    context 'uploading a template without states' do
-      it 'imports issues with the draft state' do
-        @importer.import(file: File.join(dir, 'with_comments.xml'))
-        issue = project.issues.first
-        expect(issue.state).to eq('draft')
+    context 'uploading a template with states' do
+      context 'valid states' do
+        it 'imports issues with states from the template' do
+          @importer.import(file: File.join(dir, 'with_states.xml'))
+          issue = project.issues.first
+          expect(issue.state).to eq('ready_for_review')
+        end
+      end
+
+      context 'invalid states' do
+        it 'does not import the issue' do
+          @importer.import(file: File.join(dir, 'with_invalid_states.xml'))
+          expect(project.issues.count).to eq(0)
+        end
       end
     end
   end


### PR DESCRIPTION
### Spec
With the introduction of the state column for issues/content blocks, we want to make sure that the state can be exported and imported along with the project.

**Proposed solution**
Implement an import/export V4 that adds the state attribute.