### PR TITLE
Update tag position when uploading template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.15.0 (Month 202X)
+  - Update tag position values on template upload
+
 v4.14.0 (October 2024)
   - No changes
 

--- a/lib/dradis/plugins/projects/gem_version.rb
+++ b/lib/dradis/plugins/projects/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 4
-        MINOR = 14
+        MINOR = 15
         TINY = 0
         PRE = nil
 

--- a/lib/dradis/plugins/projects/upload/v4/template.rb
+++ b/lib/dradis/plugins/projects/upload/v4/template.rb
@@ -383,11 +383,14 @@ module Dradis::Plugins::Projects::Upload::V4
       def parse_tags(template)
         logger.info { 'Processing Tags...' }
 
-        template.xpath('dradis-template/tags/tag').each do |xml_tag|
+        template.xpath('dradis-template/tags/tag').each.with_index(1) do |xml_tag, index|
           name = xml_tag.at_xpath('name').text()
           tag_params = { name: name }
           tag_params[:project_id] = project.id if Tag.has_attribute?(:project_id)
+
           tag = Tag.where(tag_params).first_or_create
+          tag.update(position: index) unless tag.position == index
+
           logger.info { "New tag detected: #{name}" }
 
           xml_tag.xpath('./taggings/tagging').each do |xml_tagging|

--- a/spec/fixtures/files/attachments_url.xml
+++ b/spec/fixtures/files/attachments_url.xml
@@ -12,4 +12,4 @@ Test Issue
 !/nodes/5/attachments/hello.jpg!
 
 ]]></text><activities></activities><comments></comments></issue></issues><methodologies></methodologies><categories>
-<category><id>2</id><name>Issue description</name></category></categories><tags><tag><id>1</id><name>!9467bd_critical</name><taggings></taggings></tag><tag><id>2</id><name>!d62728_high</name><taggings></taggings></tag><tag><id>3</id><name>!ff7f0e_medium</name><taggings></taggings></tag><tag><id>4</id><name>!6baed6_low</name><taggings></taggings></tag><tag><id>5</id><name>!2ca02c_info</name><taggings></taggings></tag></tags></dradis-template>
+<category><id>2</id><name>Issue description</name></category></categories><tags/></dradis-template>

--- a/spec/fixtures/files/with_tags.xml
+++ b/spec/fixtures/files/with_tags.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dradis-template version="2">
+  <nodes>
+    <node>
+      <id>5</id>
+      <label>Uploaded files</label>
+      <parent-id />
+      <position>0</position>
+      <properties><![CDATA[{
+}]]></properties>
+      <type-id>0</type-id>
+      <notes></notes>
+      <evidence></evidence>
+      <activities></activities>
+    </node>
+  </nodes>
+  <issues>
+    <issue>
+      <id>2</id>
+      <author>admin@securityroots.com</author>
+      <text><![CDATA[#[Title]#
+        Test Issue
+        #[Description]#
+        hello world]]>
+      </text>
+      <activities></activities>
+      <comments></comments>
+    </issue>
+  </issues>
+  <methodologies></methodologies>
+  <categories>
+    <category>
+      <id>2</id>
+      <name>Issue description</name>
+    </category>
+  </categories>
+  <tags>
+    <tag>
+      <id>1</id>
+      <name>!2ca02c_info</name>
+      <taggings></taggings>
+    </tag>
+    <tag>
+      <id>2</id>
+      <name>!ff7f0e_medium</name>
+      <taggings></taggings>
+    </tag>
+    <tag>
+      <id>3</id>
+      <name>!d62728_high</name>
+      <taggings></taggings>
+    </tag>
+    <tag>
+      <id>4</id>
+      <name>!6baed6_low</name>
+      <taggings></taggings>
+    </tag>
+    <tag>
+      <id>5</id>
+      <name>!9467bd_critical</name>
+      <taggings></taggings>
+    </tag>
+  </tags>
+</dradis-template>


### PR DESCRIPTION
### Summary

With the introduction of custom tag sorting, we want to maintain the user-set order of tags when uploading an exported project template

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
- [x] Added specs
