### PR TITLE
Update deprecated `File.exists?` to `File.exist?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+vX.X.X (Month 2025)
+  - Update File.exists? calls for ruby upgrade
+
 v4.17.0 (July 2025)
   - No changes
 

--- a/lib/dradis/plugins/projects/export/package.rb
+++ b/lib/dradis/plugins/projects/export/package.rb
@@ -10,7 +10,7 @@ module Dradis::Plugins::Projects::Export
       filename = args[:filename]
       logger   = options.fetch(:logger, Rails.logger)
 
-      File.delete(filename) if File.exists?(filename)
+      File.delete(filename) if File.exist?(filename)
 
       logger.debug{ "Creating a new Zip file in #{filename}..." }
 

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -72,7 +72,7 @@ class UploadTasks < Thor
   def template(file_path)
     require 'config/environment'
 
-    unless File.exists?(file_path)
+    unless File.exist?(file_path)
       $stderr.puts "** the file [#{file_path}] does not exist"
       exit -1
     end
@@ -98,7 +98,7 @@ class UploadTasks < Thor
   def package(file_path)
     require 'config/environment'
 
-    unless File.exists?(file_path)
+    unless File.exist?(file_path)
       $stderr.puts "** the file [#{file_path}] does not exist"
       exit -1
     end


### PR DESCRIPTION
### Summary

With the upgrade from Ruby 3.1.2 to 3.4.4 we need to update all references from `File.exists?` to `File.exist?`

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [x] Added a CHANGELOG entry
~- [ ] Added specs~